### PR TITLE
Use the current host for the mobile link

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,10 +267,10 @@
 
       <div id="survey-form-tools-container">
         <a class="button edit-form-button">Edit form</a>
-        <a href="http://beta.localdata.com/mobile/#<%= survey.slug %>">Go to the mobile app</a>
+        <a href="<%= mobile %>">Go to the mobile app</a>
         <label>
           Copy link to app 
-          <input type="text" value="http://beta.localdata.com/mobile/#<%= survey.slug %>">
+          <input type="text" value="<%= mobile %>">
         </label>
 
         <!--

--- a/js/views/forms.js
+++ b/js/views/forms.js
@@ -90,9 +90,11 @@ function($, _, Backbone, settings, api, DesignViews, BuilderViews, PreviewView) 
     },
     
     render: function() {
+      var surveyJSON = this.survey.toJSON();
       var context = {
-        survey: this.survey.toJSON(),
-        forms: this.forms.toJSON()
+        survey: surveyJSON,
+        forms: this.forms.toJSON(),
+        mobile: 'http://' + window.location.host + '/mobile/#' + surveyJSON.slug
       };
       this.$el.html(_.template($('#form-view').html(), context));
 


### PR DESCRIPTION
The link for the mobile app no longer hard codes the beta server.

Avoiding a relative link, since we could be using HTTPS for the dashboard, but we only need HTTP for the mobile app.

/cc @hampelm 
