### PR TITLE
Balance loading events

### DIFF
--- a/js/views/responses.js
+++ b/js/views/responses.js
@@ -49,9 +49,7 @@ function($, _, Backbone, moment, events, settings, api, Responses, MapView) {
 
       this.forms = options.forms;
 
-      if (this.responses.length > 0) {
-        this.render();
-      }
+      this.render();
     },
     
     // TODO: merge update and render

--- a/js/views/surveys.js
+++ b/js/views/surveys.js
@@ -196,9 +196,6 @@ function(
       };
       this.$el.html(_.template($('#survey-view').html(), context));
       
-      // Show the loading state 
-      events.publish('loading', [true]);
-
       // Render the sub components
       $('#form-view-container').hide();
       $('#export-view-container').hide();


### PR DESCRIPTION
We shouldn't set `loading` to `true` unless we know we'll later set it to `false`.

/cc @hampelm 
