### PR TITLE
Rerender if we get results for current page

### DIFF
--- a/js/views/responses.js
+++ b/js/views/responses.js
@@ -249,12 +249,17 @@ function($, _, Backbone, moment, events, settings, api, Responses, MapView) {
     },
 
     updateResponses: function () {
+      var rerender = false;
+      if (this.page === this.pageCount - 1 || this.pageCount === 0) {
+        rerender = true;
+      }
+
       // We got more responses, so let's recalculate the pagination parameters.
       this.setupPagination();
 
       // We only need to rerender if we're on the last page. Otherwise, those
       // new items don't affect the view yet.
-      if (this.page === this.pageCount - 1) {
+      if (rerender) {
         this.render();
       } else {
         var context = {


### PR DESCRIPTION
If we get a chunk of responses that should be displayed (based on paging), then we should re-render.

In the future, we can probably be a little smarter about rendering the list. Especially if the items become clickable, we shouldn't throw them out, or we could cause UI hiccups.

/cc @hampelm 
