### PR TITLE
Ensure every entry has a responses attribute

### DIFF
--- a/js/models/responses.js
+++ b/js/models/responses.js
@@ -15,7 +15,9 @@ function($, _, Backbone, settings, api) {
   var Responses = {};
 
   Responses.Model = Backbone.Model.extend({ 
-  
+    defaults: {
+      responses: {}
+    }
   });
 
   Responses.Collection = Backbone.Collection.extend({


### PR DESCRIPTION
Right now, it's possible to create a response entry through the API that has no answers attached to it. That caused problems when we try to color entries based on answers to a question. Now we ensure the dashboard models have the appropriate structure. We should also enforce the structure in the API and the mobile collection tool.

/cc @hampelm 
