### PR TITLE
Display survey zones on the dashboard

### DIFF
--- a/js/views/responses.js
+++ b/js/views/responses.js
@@ -28,7 +28,7 @@ function($, _, Backbone, moment, events, settings, api, Responses, MapView) {
   ResponseViews.MapAndListView = Backbone.View.extend({
     responses: null,
     firstRun: true,
-    surveyId: null,
+    survey: null,
     filters: {},
     mapView: null,
     listView: null,
@@ -53,6 +53,8 @@ function($, _, Backbone, moment, events, settings, api, Responses, MapView) {
 
       this.forms = options.forms;
       this.forms.on('reset', this.updateFilterChoices, this);
+
+      this.survey = options.survey;
 
       // Make sure we have forms available
       this.render();
@@ -84,7 +86,8 @@ function($, _, Backbone, moment, events, settings, api, Responses, MapView) {
       if (this.mapView === null) {
         this.mapView = new MapView({
           el: $('#map-view-container'),
-          responses: this.responses
+          responses: this.responses,
+          survey: this.survey
         });
       }
 

--- a/js/views/surveys.js
+++ b/js/views/surveys.js
@@ -205,7 +205,8 @@ function(
       this.responseListView = new ResponseViews.MapAndListView({
         el: $("#response-view-container"),
         responses: this.responses,
-        forms: this.forms
+        forms: this.forms,
+        survey: this.survey
       });
 
       // Form view


### PR DESCRIPTION
Show the same zones on the dashboard that we show on the mobile web app, if they exist.

When there are no results, zoom to fit the zones on the map. Otherwise, zoom as usual to fit the responses.

/cc @hampelm 
