### PR TITLE
Reset the surveys collection when we create the dashboard view

### DIFF
--- a/src/js/views/dashboard.js
+++ b/src/js/views/dashboard.js
@@ -37,7 +37,9 @@ function($, _, Backbone, settings, IndexRouter, Surveys, SurveyViews) {
     },
 
     update: function() {
-      this.surveys.fetch();
+      this.surveys.fetch({
+        reset: true
+      });
     },
     
     render: function() {


### PR DESCRIPTION
The default behavior changed in Backbone 1.0.

/cc @hampelm
