### PR TITLE
Fix a bug when handling top-level questions

### DIFF
--- a/src/js/models/forms.js
+++ b/src/js/models/forms.js
@@ -13,6 +13,36 @@ function($, _, Backbone, settings) {
 
   var Forms = {};
 
+  // Recursive helper method used by getFlattenedForm
+  // Modifies the flattenedForm argument.
+  function flattenForm(question, flattenedForm) {
+    // Add the question to the list of questions
+    // Naive -- takes more space than needed (because it includes subquestions)
+    if(question.type !== 'checkbox') {
+      flattenedForm.push(question);
+    }
+
+    // Check if there are sub-questions associated with any of the answers
+    _.each(question.answers, function(answer){
+
+      // Add each checkbox answer as a separate question
+      if (question.type === 'checkbox') {
+        flattenedForm.push({
+          name: answer.name,
+          text: question.text + ': ' + answer.text
+        });
+      }
+
+      if (answer.questions !== undefined) {
+        _.each(answer.questions, function(question) {
+          // Recusively call flattenForm to process those questions.
+          flattenForm(question, flattenedForm);
+        });
+      }
+    });
+  };
+
+
   // Forms model
   Forms.Model = Backbone.Model.extend({
     initialize: function(options) {
@@ -66,38 +96,6 @@ function($, _, Backbone, settings) {
       }
     },
 
-    // Helper method used by the recursive getFlattenedForm
-    flattenForm: function(question, flattenedForm) {
-
-      // Add the question to the list of questions
-      // Naive -- takes more space than needed (because it includes subquestions)
-      if(question.type !== 'checkbox') {
-        flattenedForm.push(question);
-      }
-
-      // Check if there are sub-questions associated with any of the answers
-      _.each(question.answers, function(answer){
-
-        // Add each checkbox answer as a separate question
-        if(question.type === 'checkbox') {
-          flattenedForm.push({
-            name: answer.name,
-            text: question.text + ': ' + answer.text
-          });
-        }
-
-        if (answer.questions !== undefined) {
-          _.each(answer.questions, function(question) {
-            // Recusively call flattenForm to process those questions.
-            return this.flattenForm(question, flattenedForm);
-
-          }, this);
-        }
-      }, this);
-
-      return flattenedForm;
-    },
-
     // Returns the most recent form as a flat list of question objects
     // Objects have name (functions as id), text (label of the question)
     getFlattenedForm: function() {
@@ -109,7 +107,7 @@ function($, _, Backbone, settings) {
       // Process the form if we have one
       if (mostRecentForm !== undefined) {
         _.each(mostRecentForm.get("questions"), function(question) {
-          flattenedForm = flattenedForm.concat(this.flattenForm(question, flattenedForm));
+          flattenForm(question, flattenedForm);
         }, this);
 
         // Make sure there's only one question per ID.


### PR DESCRIPTION
Top-level questions resulted in duplicated flattened-question arrays. A large number of top-level questions would grow the flattened array exponentially.

/cc @hampelm 
