### PR TITLE
Really cheap way of showing the first stat

### DIFF
--- a/src/js/views/responses/filter.js
+++ b/src/js/views/responses/filter.js
@@ -90,6 +90,9 @@ function($, _, Backbone, events, _kmq, settings, api, Responses, Stats, template
         mapping: this.forms.map()
       };
       this.$el.html(this.template(context));
+
+      // TODO: This is a cheap hack to show the first stat
+      // We should do this in a more robust way so HTML changes don't break it.
       $($('.question label')[0]).trigger('click');
     },
 


### PR DESCRIPTION
Issue #269 asks if we should start the deep dive with the first question selected. Currently, this would require some moderate refactoring. This is a really cheap one-line solution. It's not the best experience for larger surveys (there will be a period when the map changes after the stats load), but it's not bad. 
