### PR TITLE
Don't show deep dive on load

### DIFF
--- a/src/js/views/responses/filter.js
+++ b/src/js/views/responses/filter.js
@@ -90,10 +90,6 @@ function($, _, Backbone, events, _kmq, settings, api, Responses, Stats, template
         mapping: this.forms.map()
       };
       this.$el.html(this.template(context));
-
-      // TODO: This is a cheap hack to show the first stat
-      // We should do this in a more robust way so HTML changes don't break it.
-      $($('.question label')[0]).trigger('click');
     },
 
     /**


### PR DESCRIPTION
Fixes an issue where the overview map is replaced with the deep dive when the stats load. This bug also has the ill effect of creating too many tile requests. 
