### PR TITLE
Use existing zones as individual features, not as one featuregroup

### DIFF
--- a/src/js/views/maps/draw.js
+++ b/src/js/views/maps/draw.js
@@ -196,7 +196,7 @@ function($, _, Backbone, L, moment, events, _kmq, settings, api,
           zone.layer = layer;
         }.bind(this));
 
-        this.zones.reset(zones);
+        this.zones.reset(zones.features);
       }
 
       // Renter the form for the zones


### PR DESCRIPTION
Avoids a bug where the zones display correctly, but the associated form doesn't render for all the zones if we've manually added them. 
