### PR TITLE
Handle questions that are not in the API’s stats

### DIFF
--- a/src/js/views/responses/filter.js
+++ b/src/js/views/responses/filter.js
@@ -75,15 +75,23 @@ function($, _, Backbone, events, _kmq, settings, api, Responses, Stats, template
             return sum + count;
           }, 0);
 
+          var noResponseCount;
+          if (questionStats) {
+            noResponseCount = questionStats[NOANSWER];
+          }
+          if (noResponseCount === undefined) {
+            noResponseCount = 0;
+          }
+
           questions[question].answers = [{
             text: ANSWER,
             value: ANSWER,
-            count: total - questionStats[NOANSWER],
+            count: total - noResponseCount,
             color: settings.colorRange[1]
           }, {
             text: NOANSWER,
             value: NOANSWER,
-            count: questionStats[NOANSWER],
+            count: noResponseCount,
             color: settings.colorRange[0]
           }];
         } else if (type === 'file') {


### PR DESCRIPTION
If a text question has never been answered, there's no info on it in the stats we get from the API. Use a count of 0 as a workaround.

See LocalData/localdata-api#185

/cc @hampelm 
