### PR TITLE
Remove unused code from map.js 

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -254,15 +254,6 @@
     </script>
 
 
-    <!-- Map ..............................................................-->
-    <script type="text/template" id="map-view">
-      <div class="b nomargin">
-        <div id="map" ></div>
-      </div>
-      <div class="map-loading"></div>
-    </script>
-
-
     <!-- Upload ...........................................................-->
     <script type="text/template" id="upload-view">
       <h3>Upload scanned paper forms</h3>

--- a/src/js/templates/responses/map.html
+++ b/src/js/templates/responses/map.html
@@ -1,0 +1,4 @@
+<div class="b nomargin">
+    <div id="map"></div>
+</div>
+<div class="map-loading"></div>


### PR DESCRIPTION
I removed the code we're using to render objects on the map, since we no longer do that (and haven't in some time). Simplifying the map code will make new features more readable. We should keep track of this old code, though, since there are some lessons about handling lots of features. 

Also adds our current file-based template format and moves the map template out of index.html. 
