### PR TITLE
Use the feature service’s parcels source by default

### DIFF
--- a/src/js/views/surveys.js
+++ b/src/js/views/surveys.js
@@ -191,8 +191,13 @@ function(
       // Get some of the optional parameters
       // Custom geoObjectSource
       var geoObjectSource = $(".survey-geoObjectSource").val();
-      if(geoObjectSource) {
+      if (geoObjectSource) {
         survey.geoObjectSource = $.parseJSON(geoObjectSource);
+      } else {
+        survey.geoObjectSource = {
+          type: 'LocalData',
+          source: '/api/features?type=parcels&bbox={{bbox}}'
+        };
       }
 
       // Custom survey type


### PR DESCRIPTION
Going forward, we should default to the feature service and deprecate the parcel service. This does not cover selection of a source, but it creates a better default behavior.

Fixes #378 

/cc @hampelm 
