### PR TITLE
Re-add Google Analytics tracking code

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -449,6 +449,15 @@
     </script>
 
     <script data-main="js/main" src="js/require.js"></script>
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
+      ga('create', 'UA-39867070-1', 'auto');
+      ga('send', 'pageview');
+
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Did we remove it for a reason? 

This is the tracking code for the app-specific analytics (not the public site's analytics) 
