### PR TITLE
Redirect users when they visit the homepage while not logged in

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -58,15 +58,16 @@ function($, _, Backbone, events, settings, api, RootView, LoadingView, Users) {
     events.subscribe('loading', LD.setLoading);
     events.subscribe('navigate', LD.navigateTo);
 
-    // Handle redirecting to the login page
-    // Currently not used.
+    // Handle redirecting to the login page if not logged in when visiting
+    // the homepage.
     var redirectToLogin = function() {
       // Don't keep redirecting to login
       var isLogin = Backbone.history.fragment.indexOf("login") !== -1;
       var isRegister = Backbone.history.fragment.indexOf("register") !== -1;
       var isReset = Backbone.history.fragment.indexOf("reset") !== -1;
+      var isSurvey = Backbone.history.fragment.indexOf("survey") !== -1;
 
-      if (isLogin || isRegister || isReset) {
+      if (isLogin || isRegister || isReset || isSurvey) {
         return;
       }
 
@@ -79,7 +80,7 @@ function($, _, Backbone, events, settings, api, RootView, LoadingView, Users) {
       console.log("Ajax error: " + xhr.status);
       if (xhr.status === 401) {
         // togglePublicMode();
-        // redirectToLogin();
+        redirectToLogin();
       }
     });
   };


### PR DESCRIPTION
When users visit the app homepage while not logged in, they see a sad white screen. Let's redirect them to the login to make life easier. Anonymous users browsing surveys will not be effected. 

Looks like this right now:
![2014-09-08 05 24 29 pm](https://cloud.githubusercontent.com/assets/86435/4193082/a08a4ac4-379e-11e4-822f-8365371b8083.png)

Will look like this:

![2014-09-08 05 25 40 pm](https://cloud.githubusercontent.com/assets/86435/4193094/af999240-379e-11e4-81b6-63d6954a01d0.png)
