### PR TITLE
Don’t re-zoom the map on every refresh click

### DIFF
--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -233,7 +233,12 @@ function($, _, Backbone, L, moment, _kmq, settings, api, template) {
         if (this.survey.has('zones')) {
           this.plotZones();
         }
-        this.listenTo(this.survey, 'change', this.plotZones);
+
+        this.listenTo(this.survey, 'change', function () {
+          if (this.survey.hasChanged('zones')) {
+            this.plotZones();
+          }
+        });
 
         this.selectDataMap();
       }

--- a/src/js/views/responses/responses.js
+++ b/src/js/views/responses/responses.js
@@ -127,7 +127,6 @@ function($, _, Backbone, moment, events, _kmq, settings, api,
 
       // Listen for new responses
       this.survey.on('change', this.mapView.update);
-      this.survey.on('change', this.mapView.fitBounds);
     },
 
     mapClickHandler: function(event) {


### PR DESCRIPTION
Users often zoom to where activity is happening and want to see new results populate that part of the map. Fitting the full response bounds prevents that and can often lead to long waits while we redraw coarse tiles.
