### PR TITLE
Implement simple date range selector

### DIFF
--- a/src/css/sass/components/filters.scss
+++ b/src/css/sass/components/filters.scss
@@ -2,72 +2,79 @@
   display: none;
 }
 
-.filters label,
-.filters .question {
-  cursor: pointer;
-}
-
-.filters .question {
-}
-
-.filters h3 {
-  font-size: 24px;
-}
-
-.filters label {
-  font-family: $bold;
-  line-height: 1.2;
-  display: block;
-  position: relative;
-  padding-left: 32px;
-}
-
-.filters .question {
-  margin-bottom: 2em;
-}
-
-.filters .answers {
-  .circle,
-  button {
-    display: none;
+.filters {
+  .filter {
+    margin-bottom: 1em;
   }
-}
 
-.filters .answers button {
-  margin-top: 10px;
-}
+  label,
+  .question {
+    cursor: pointer;
+  }
 
-.filters .answer {
-  position: relative;
-  padding-left: 32px;
-  clear: both;
-  margin-top: 10px
-}
+  .question {
+  }
 
-.filters .circle {
-  position: absolute;
-  left: 0;
-  border-radius: 50%;
-  width: 20px;
-  height: 20px;
-  border: 3px solid #fff;
-  background: transparent;
-}
+  h3 {
+    font-size: 24px;
+    margin-bottom: 0;
+  }
 
-.filters .selected {
-  .circle {
-    background: #6e6663;
+  label {
+    font-family: $bold;
+    line-height: 1.2;
     display: block;
+    position: relative;
+    padding-left: 32px;
+  }
+
+  .question {
+    margin-bottom: 2em;
+  }
+
+  .answers {
+    .circle,
+    button {
+      display: none;
+    }
   }
 
   .answers button {
-    display: block;
+    margin-top: 10px;
   }
 
+  .answer {
+    position: relative;
+    padding-left: 32px;
+    clear: both;
+    margin-top: 10px
+  }
+
+  .circle {
+    position: absolute;
+    left: 0;
+    border-radius: 50%;
+    width: 20px;
+    height: 20px;
+    border: 3px solid #fff;
+    background: transparent;
+  }
+
+  .selected {
+    .circle {
+      background: #6e6663;
+      display: block;
+    }
+
+    .answers button {
+      display: block;
+    }
+  }
+
+  .circle.inactive {
+    background: transparent ! important;
+  }
 }
 
 
-.filters .circle.inactive {
-  background: transparent ! important;
-}
 

--- a/src/js/models/stats.js
+++ b/src/js/models/stats.js
@@ -17,18 +17,20 @@ function($, _, Backbone, settings) {
     urlRoot: settings.api.baseurl + "/surveys/",
 
     url: function() {
-      return this.urlRoot + this.id + '/stats/';
+      return this.urlRoot + this.id + '/stats?' +  $.param(this.params);
     },
 
     initialize: function(options) {
       _.bindAll(this, 'parse', 'url');
+
+      this.attributes = {}; // otherwise fetch doesn't seem to remove old vals
+      this.params = options.params || {};
       this.fetch();
     },
 
     parse: function(response) {
       return response.stats;
     }
-
   });
 
   return Stats;

--- a/src/js/templates/filters/filters.html
+++ b/src/js/templates/filters/filters.html
@@ -1,0 +1,14 @@
+<h3>Filter responses</h3>
+
+<div class="date-filters filter">
+  <h4>Filter by date</h4>
+  <select id="datefilter">
+    <option value="all">All responses</option>
+    <option value="hour">Past hour</option>
+    <option value="today">Today</option>
+    <option value="week">Past 7 days</option>
+    <!-- <option value="other">Custom range</option> -->
+  </select>
+</div>
+
+<div class="question-filters filter"></div>

--- a/src/js/templates/filters/loading.html
+++ b/src/js/templates/filters/loading.html
@@ -1,3 +1,0 @@
-<h3>Filter responses</h3>
-
-<p>We're loading your deep-dive data.</p>

--- a/src/js/templates/filters/question-filters.html
+++ b/src/js/templates/filters/question-filters.html
@@ -1,6 +1,7 @@
-<h3>Filter responses</h3>
 
 <div class="questions">
+
+  <h4>Filter by question</h4>
 
   <% _.each(_.keys(questions), function (name) {%>
     <% if(! _.has(questions, name)) { return; } %>

--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -55,7 +55,6 @@ function($, _, Backbone, L, moment, _kmq, settings, api, template) {
 
     initialize: function(options) {
       L.Icon.Default.imagePath = '/js/lib/leaflet/images';
-      console.log("Init map view");
       _.bindAll(this,
         'render',
         'controlUTFZoom',
@@ -263,12 +262,11 @@ function($, _, Backbone, L, moment, _kmq, settings, api, template) {
       }
       url = url + '/tile.json';
 
-      console.log("Getting tilejson", url);
       // Get TileJSON
       $.ajax({
         url: url,
-        type: 'GET',
         dataType: 'json',
+        data: this.daterange,
         cache: false
       }).done(this.addTileLayer)
       .fail(function(jqXHR, textStatus, errorThrown) {
@@ -292,12 +290,16 @@ function($, _, Backbone, L, moment, _kmq, settings, api, template) {
       this.selectDataMap();
     },
 
+    setDate: function(options) {
+      this.daterange = options;
+      this.map.invalidateSize();
+      this.selectDataMap();
+    },
 
     clearFilter: function () {
       this.filter = null;
       this.selectDataMap();
     },
-
 
     /**
      * Plot survey zones on the map


### PR DESCRIPTION
Let users select a recent date range to filter responses.

**Requires the [date filters PR in localdata-tiles](https://github.com/LocalData/localdata-tiles/pull/120)**. 

Stacks correctly with other filters. 

Currently has 4 date options; A future iteration will have a custom date range selector, but this is a good starting point for many users:
-  All
- Past hour
- Today
- Past 7 days

I'm not entirely happy with the style of the date dropdown -- the native browser widget doesn't match our design. However, I wanted to get this out there, and we don't currently have a dropdown style. 

By default, it says "All responses". Should it say "all dates" for consistency? 

![2014-10-23 05 06 46 pm](https://cloud.githubusercontent.com/assets/86435/4761470/936c8578-5af8-11e4-9464-6397eac84832.png)

![2014-10-23 05 04 55 pm](https://cloud.githubusercontent.com/assets/86435/4761451/5cfc75b6-5af8-11e4-8c71-3d7256f0a56c.png)
