### PR TITLE
Make the form data flow more Backbone-ish

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -222,32 +222,6 @@ define(function (require) {
   //   });
   // };
 
-
-  // Get the form for the current survey
-  api.getForm = function(callback) {
-    console.log("API: getting form data");
-    var url = api.getSurveyURL() + "/forms";
-
-    $.getJSON(url, function(data){
-
-      // Get only the mobile forms
-      var mobileForms = _.filter(data.forms, function(form) {
-        if (_.has(form, 'type')) {
-          if (form.type === 'mobile'){
-            return true;
-          }
-        }
-        return false;
-      });
-
-      // Endpoint should give the most recent form first.
-      // And that's what we'll use
-      settings.formData = mobileForms[0];
-
-      callback();
-    });
-  };
-
   // Add a form to a survey
   //
   // @param {Object} form

--- a/src/js/models/forms.js
+++ b/src/js/models/forms.js
@@ -147,8 +147,7 @@ function($, _, Backbone, settings) {
 
     parse: function(response) {
       if (response.forms.length === 0) {
-        var newForm = new Forms.Model({ 'questions': [] });
-        return [ newForm ];
+        return [];
       }
 
       return response.forms;

--- a/src/js/views/builder.js
+++ b/src/js/views/builder.js
@@ -2,24 +2,18 @@
 /*globals define: true */
 /*globals console: true */
 
-define([
-  'jquery',
-  'lib/lodash',
-  'backbone',
-  'lib/kissmetrics',
-
-  // LocalData
-  'settings',
-  'api',
-
-  // Templates
-  'text!templates/surveys/form-editor.html',
-
-  'views/forms'
-],
-
-function($, _, Backbone, _kmq, settings, api, template, FormViews) {
+define(function (require) {
   'use strict';
+
+  var $ = require('jquery');
+  var _ = require('lib/lodash');
+  var Backbone = require('backbone');
+  var _kmq = require('lib/kissmetrics');
+
+  var api = require('api');
+  var template = require('text!templates/surveys/form-editor.html');
+  var Form = require('models/forms');
+
 
   var Builder = {};
 
@@ -78,7 +72,7 @@ function($, _, Backbone, _kmq, settings, api, template, FormViews) {
       console.log('Saving form');
       _kmq.push(['record', 'Survey questions saved']);
 
-      api.createForm(settings.formData, function(){
+      api.createForm(this.forms.getMostRecentForm(), function(){
         console.log('Form successfully saved');
         $(".saved").fadeIn().css("display","inline-block").delay(2000).fadeOut();
       });
@@ -110,16 +104,24 @@ function($, _, Backbone, _kmq, settings, api, template, FormViews) {
       this.formQuestions = $('#editor');
       this.formQuestions.html('');
 
+      var form = this.forms.getMostRecentForm();
+      var formData;
+
       // Default to a blank question if the form is empty
-      if (settings.formData === undefined) {
-        settings.formData = {};
-        settings.formData.questions = [];
-        settings.formData.questions.push(this.makeBlankQuestion());
+      if (form === undefined) {
+        formData = {};
+        formData.questions = [];
+        formData.questions.push(this.makeBlankQuestion());
+        this.forms.add(new Form.Model({ questions: formData.questions }));
+      } else {
+        formData = {
+          questions: form.get('questions')
+        };
       }
 
       // Render form
-      _.each(settings.formData.questions, function (question, questionIndex) {
-        this.renderQuestion(question, undefined, undefined, undefined, undefined, questionIndex, settings.formData.questions);
+      _.each(formData.questions, function (question, questionIndex) {
+        this.renderQuestion(question, undefined, undefined, undefined, undefined, questionIndex, formData.questions);
       }, this);
     },
 

--- a/src/js/views/design.js
+++ b/src/js/views/design.js
@@ -62,6 +62,8 @@ function($, _, Backbone, events, settings, api, SurveyModels, FormModels, Previe
         reset: true
       });
 
+      this.forms = options.forms;
+
       this.el = options.el;
       this.$el = $(options.el);
 
@@ -107,20 +109,33 @@ function($, _, Backbone, events, settings, api, SurveyModels, FormModels, Previe
       var formToSave = formCollection.toJSON()[0];
       delete formToSave.created;
       delete formToSave.id;
+
+      console.log('Form Designer: using the form from survey ' + formCollection.get('surveyId'));
+
+      this.forms.add(new FormModels.Model(formToSave));
+
       api.createForm(formToSave, $.proxy(function() {
         this.trigger('formAdded');
       },this));
     },
 
     useSurvey: function(event) {
-      console.log("Using the survey");
+      console.log('Form Designer: using the sample form');
+
+      this.forms.add(new FormModels.Model(exampleForm));
+
+      // TODO: Use Model.save
       api.createForm(exampleForm, $.proxy(function() {
         this.trigger('formAdded');
       },this));
     },
 
     useBlankSurvey: function(event) {
-      console.log("Using the survey");
+      console.log('Form Designer: using the blank form');
+
+      this.forms.add(new FormModels.Model(blankForm));
+
+      // TODO: Use Model.save
       api.createForm(blankForm, $.proxy(function() {
         this.trigger('formAdded');
       },this));

--- a/src/js/views/forms.js
+++ b/src/js/views/forms.js
@@ -50,7 +50,8 @@ function($, _, Backbone, settings, api, template, DesignViews, BuilderViews, Pre
 
         var designView = new DesignViews.DesignView({
           el: '#survey-design-container',
-          model: this.survey
+          model: this.survey,
+          forms: this.forms
         });
         designView.render();
 
@@ -90,15 +91,14 @@ function($, _, Backbone, settings, api, template, DesignViews, BuilderViews, Pre
 
       this.$el.html(this.template(context));
 
-      // old: Make sure we have up-to-date form data before showing the design view
-      api.getForm(function() {
-        if (settings.formData === undefined) {
-          this.showDesigner();
-        }else {
-          this.showBuilder();
-        }
-      }.bind(this));
-
+      // Decide if we should show the Builder (view+edit) or the Designer
+      // (choose from a template)
+      if (this.forms.models.length > 0) {
+        // We have a form, so let the user view and edit it.
+        this.showBuilder();
+      } else {
+        this.showDesigner();
+      }
     }
   });
 

--- a/src/js/views/surveys.js
+++ b/src/js/views/surveys.js
@@ -249,28 +249,38 @@ define(function(require, exports, module) {
         survey: this.survey.toJSON()
       }));
 
-      // Map the responses
-      this.mapAndListView = new ResponseViews.MapAndListView({
-        // responses: this.responses,
-        forms: this.forms,
-        survey: this.survey
-      });
-
-      if(this.filters) {
-        this.mapAndListView.showFilters();
-      }
-
       // Form view
       this.formView = new FormViews.FormView({
         survey: this.survey,
         forms: this.forms
       });
 
-      // Review view
-      this.reviewView = new ReviewView({
-        survey: this.survey,
-        forms: this.forms
-      });
+      var surveyFullyCreated = (this.forms &&
+                                this.forms.models &&
+                                this.forms.models.length > 0);
+
+      if (surveyFullyCreated) {
+        // Map the responses
+        this.mapAndListView = new ResponseViews.MapAndListView({
+          // responses: this.responses,
+          forms: this.forms,
+          survey: this.survey
+        });
+
+        if(this.filters) {
+          this.mapAndListView.showFilters();
+        }
+        // Review view
+        this.reviewView = new ReviewView({
+          survey: this.survey,
+          forms: this.forms
+        });
+      } else {
+        // Once the form has been created, we should rerender, so we can display all of the other components.
+        this.listenToOnce(this.forms, 'add', function () {
+          this.render();
+        });
+      }
 
       // Export, Settings views
       this.exportView = new ExportView({survey: this.survey });
@@ -293,6 +303,10 @@ define(function(require, exports, module) {
         $('#tab-survey-export').hide();
         $('#tab-survey-settings').hide();
         $('#tab-survey-app').hide();
+      }
+
+      if (!surveyFullyCreated) {
+        location.href = '/#surveys/' + settings.slug + '/form';
       }
     },
 


### PR DESCRIPTION
Remove reliance on the global settings.formData reference
Use Backbone to get the forms, so we can rely on the Collection/Model to access the latest form or confirm that there is none
Make sure we show the appropriate view if there is no form

Addresses #401 

/cc @hampelm 
