### PR TITLE
Enable UTF grids at zoom 14

### DIFF
--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -21,7 +21,7 @@ define([
 function($, _, Backbone, L, moment, _kmq, settings, api, template) {
   'use strict';
 
-  var MIN_GRID_ZOOM = 16; // furthest out we'll have interactive grids.
+  var MIN_GRID_ZOOM = 14; // furthest out we'll have interactive grids.
 
   function flip(a) {
     return [a[1], a[0]];


### PR DESCRIPTION
Large parcels are somewhat clickable at zoom 14. Addresses #407. I wonder if we should also only enable the UTF zoom limit for surveys with >(arbitrary number) responses? Maybe >1,000?

Zoom 14 looks like this:

![2014-10-29 12 41 55 pm](https://cloud.githubusercontent.com/assets/86435/4830025/be4b6494-5f8a-11e4-83c9-2181863b11be.png)
