### PR TITLE
Support editing responses

### DIFF
--- a/src/css/sass/components/surveys.scss
+++ b/src/css/sass/components/surveys.scss
@@ -114,6 +114,15 @@
     top: 20px;
   }
 
+  button.action-save-edit,
+  button.action-cancel-edit {
+    display: none;
+  }
+
+  .edit {
+    display: none;
+  }
+
   .time, .collector {
     color: $body-accent;
   }
@@ -143,6 +152,13 @@
       .review-tools {
         display: inline-block;
         float: left;
+        padding-right: 5px;
+        border-right: 3px solid $thinpink;
+        margin-right: 15px;
+
+        button {
+          margin-bottom: 0;
+        }
       }
 
       .action-show-confirm {

--- a/src/css/sass/layout.scss
+++ b/src/css/sass/layout.scss
@@ -15,8 +15,21 @@ body {
 
 .out {
   background: #fff;
-  overflow: auto;
 }
+
+/* Clearfix without overflow */
+.out:before,
+.out:after {
+  content:"";
+  display:table;
+}
+.out:after {
+  clear:both;
+}
+.out {
+  zoom:1; /* For IE 6/7 (trigger hasLayout) */
+}
+
 
 .in {
   margin: 0px auto;

--- a/src/js/templates/responses/item.html
+++ b/src/js/templates/responses/item.html
@@ -35,11 +35,24 @@
       <% } %>
     </span>
     <span class="value"><strong><%- resp %></strong></span>
+
+    <select class="edit" data-question="<%- key %>">
+      <% if (form[key]) { %>
+        <% _.each(form[key].answers, function(answer) { %>
+          <option
+            value="<%- answer.value %>"
+            <% if (answer.value === resp) { %> selected="selected" <% } %>>
+            <%- answer.text %>
+          </option>
+        <% }); %>
+      <% } %>
+    </select>
+
   </div>
 <% }); %>
 </div>
 
-<% if (surveyOptions.loggedIn) { %>}
+<% if (surveyOptions.loggedIn) { %>
 <div class="response-tools">
   <% if (surveyOptions.showReviewTools) { %>
     <div class="review-tools">
@@ -55,6 +68,10 @@
       <% } %>
     </div>
   <% } %>
+
+  <button class="mini action-show-edit"><i class="icon-pencil"></i> Edit</button>
+  <button class="mini flex action-cancel-edit">Cancel edits</button>
+  <button class="mini action-save-edit">Save</button>
 
   <button class="mini danger action-show-confirm"><i class="icon-trash"></i> Delete</button>
 

--- a/src/js/views/responses/item.js
+++ b/src/js/views/responses/item.js
@@ -26,11 +26,21 @@ function($, _, Backbone, events, settings, api, Responses, template) {
 
     template: _.template(template),
 
+    responseEdits: {}, // changes to make to the responses object.
+
     events: {
+      // Deleting
       'click .action-show-confirm': 'confirm',
       'click .action-delete': 'destroy',
       'click .cancel': 'cancel',
 
+      // Editing
+      'click .action-show-edit': 'edit',
+      'click .action-save-edit': 'save',
+      'click .action-cancel-edit': 'cancelEdit',
+      'change .edit': 'questionEdited',
+
+      // Flagging
       'click .action-flag': 'flag',
       'click .action-accept': 'accept'
     },
@@ -41,10 +51,10 @@ function($, _, Backbone, events, settings, api, Responses, template) {
 
       this.surveyOptions = options.surveyOptions || {};
       this.labels = options.labels;
+      this.forms = options.forms;
     },
 
     render: function() {
-      console.log("Re-rendering model", this.model);
       var $el = $(this.el);
 
       this.surveyOptions.loggedIn = settings.user.isLoggedIn();
@@ -52,6 +62,7 @@ function($, _, Backbone, events, settings, api, Responses, template) {
       var options = {
         r: this.model.toJSON(),
         labels: this.labels,
+        form: this.forms.getFlattenedForm(),
         surveyOptions: this.surveyOptions
       };
 
@@ -59,6 +70,7 @@ function($, _, Backbone, events, settings, api, Responses, template) {
       return this;
     },
 
+    // Deleting
     confirm: function(event) {
       event.preventDefault();
       this.$('.action-show-confirm').hide();
@@ -89,6 +101,59 @@ function($, _, Backbone, events, settings, api, Responses, template) {
       });
     },
 
+
+    // Editing
+    edit: function(event) {
+      event.preventDefault();
+      this.$('.value').hide();
+      this.$('.action-show-edit').hide();
+
+      this.$('.edit').show();
+      this.$('.action-save-edit').show();
+      this.$('.action-cancel-edit').show();
+    },
+
+    questionEdited: function(event) {
+      var question = $(event.target).attr('data-question');
+      var answer = $(event.target).val();
+
+      this.responseEdits[question] = answer;
+    },
+
+    cancelEdit: function(event) {
+      event.preventDefault();
+
+      // Show the values and edit button
+      this.$('.value').show();
+      this.$('.action-show-edit').show();
+
+      // Hide the form and save / cancel buttons
+      this.$('.edit').hide();
+      this.$('.action-save-edit').hide();
+      this.$('.action-cancel-edit').hide();
+
+      // Fetch the attributes to make sure we have the latest version.
+      this.model.fetch();
+    },
+
+    save: function(event) {
+      event.preventDefault();
+
+      this.model.save({
+        responses: this.responseEdits
+      }, {
+        patch: true,
+        wait: true, // wait until sync to update attributes
+        success: function (event) {
+          // We need to fetch the model because patch resets the local
+          // attributes.
+          this.model.fetch({ reset: true });
+        }.bind(this)
+      });
+    },
+
+
+    // Flagging
     flag: function(event) {
       event.preventDefault();
       this.model.save({

--- a/src/js/views/responses/list.js
+++ b/src/js/views/responses/list.js
@@ -39,9 +39,9 @@ function($, _, Backbone, events, settings, api, Responses, ResponseView, templat
     },
 
     initialize: function(options) {
-      console.log("Init list view", options);
       this.listenTo(this.collection, 'add', this.render);
       this.labels = options.labels;
+      this.forms = options.forms;
       this.surveyOptions = options.surveyOptions;
     },
 
@@ -77,6 +77,7 @@ function($, _, Backbone, events, settings, api, Responses, ResponseView, templat
         var item = new ResponseView({
           model: response,
           labels: this.labels,
+          forms: this.forms,
           surveyOptions: this.surveyOptions
         });
         $el.find('.responses-list').append(item.render().el);

--- a/src/js/views/responses/responses.js
+++ b/src/js/views/responses/responses.js
@@ -146,6 +146,7 @@ define(function(require, exports, module) {
         el: '#responses-list-container',
         collection: rc,
         labels: this.forms.getQuestions(),
+        forms: this.forms,
         surveyOptions: surveyOptions
       });
 


### PR DESCRIPTION
Lets logged-in users edit responses. 

![screen shot 2014-11-21 at 1 01 23 pm](https://cloud.githubusercontent.com/assets/86435/5146835/9bccad1e-717e-11e4-8f82-4da78c482657.png)

---

![screen shot 2014-11-21 at 1 01 28 pm](https://cloud.githubusercontent.com/assets/86435/5146836/9dc3406a-717e-11e4-84ab-0dcf94af6c7c.png)

Currently uses native form styling.  I experiment with [customSelect](http://adam.co/lab/jquery/customselect/) but wasn't able to come up with a style that preserved elements of the layout and looked intuitive. I'd still like to use native styling, but I don't think it should block the functionality. 

Also fixes an overflow problem by switching clearfix method.
