### PR TITLE
Fix graph overflow and remove report border

### DIFF
--- a/src/css/sass/components/multi.scss
+++ b/src/css/sass/components/multi.scss
@@ -138,14 +138,13 @@
 
   #stats-view-container {
     position: absolute;
-    border: 5px solid $thinpink;
     background: #fff;
     width: 80%;
     left: 10%;
     top: 20px;
 
     .report {
-      margin: 3%;
+      margin-bottom: 3%;
       overflow: auto;
       border-bottom: 3px solid #thinpink;
     }

--- a/src/js/views/projects/datalayers/survey/stats-survey.js
+++ b/src/js/views/projects/datalayers/survey/stats-survey.js
@@ -137,6 +137,10 @@ define(function (require) {
           select: {
             r: 8
           }
+        },
+        padding: {
+          left: 15,
+          right: 15
         }
       });
 


### PR DESCRIPTION
Removes the border around the reports. 
Also fixes the issue where x-axis labels on the activity graph would get cut off on the far left and right. 
