### PR TITLE
Support layer controls for carto layers

### DIFF
--- a/src/css/sass/components.scss
+++ b/src/css/sass/components.scss
@@ -112,7 +112,7 @@
   position: absolute;
   left: 0px;
   top: 0px;
-  padding: 20px;
+  padding: 20px 20px 0 20px;
   background: white;
   width: 340px;
 

--- a/src/js/templates/projects/layerControl.html
+++ b/src/js/templates/projects/layerControl.html
@@ -6,7 +6,9 @@
     </span>
     <% } %>
     <span class="title">
-      <%= meta.count %>
+      <% if (meta.count) { %>
+        <%= meta.count %>
+      <% } %>
       <%= name %> &nbsp; <i class="fa fa-angle-right"></i>
     </span>
 </h4>

--- a/src/js/templates/responses/embed-multi.html
+++ b/src/js/templates/responses/embed-multi.html
@@ -22,12 +22,8 @@
 
   <div class="control-pane">
     <div id="deep-dive-count-container"></div>
-    <!--<button href="" class="button mini flex action-show-filters">
-      Filter data <i class="fa fa-chevron-right"></i>
-    </button>
-    <div class="selected-filters"></div>-->
     <div class="layers"></div>
-
+    <div class="static-layers"></div>
   </div>
   <div id="filter-view-container" class="settings-container"></div>
 </div>

--- a/src/js/views/maps/cartodb-layer.js
+++ b/src/js/views/maps/cartodb-layer.js
@@ -9,30 +9,33 @@ define(function (require, exports, module) {
   var Backbone = require('backbone');
   var L = require('lib/leaflet/leaflet.tilejson');
   var Promise = require('lib/bluebird');
-  
+
   var settings = require('settings');
 
   var infoTemplate = require('text!templates/cartodb-info.html');
-  
+  var template = require('text!templates/projects/layerControl.html');
+
+
+  // Render an infowindow for a selected cartodb map item
   var ItemView = Backbone.View.extend({
     template: _.template(infoTemplate),
-    
+
     events: {
       'click .close': 'remove'
     },
-    
+
     initialize: function (options) {
       this.layerOptions = options.layerOptions;
       this.data = options.data;
     },
-    
+
     render: function () {
       var context = {
         name: this.data[this.layerOptions.humanReadableField],
         centroid: JSON.parse(this.data.centroid),
         googleKey: settings.GoogleKey
       };
-      
+
       var names = this.layerOptions.fieldNames;
       context.fields = _.map(_.keys(names), function (name) {
         return {
@@ -42,7 +45,7 @@ define(function (require, exports, module) {
       }, this);
       this.$el.html(this.template(context));
       return this;
-    },
+    }
   });
 
   // The View
@@ -50,41 +53,115 @@ define(function (require, exports, module) {
   // later need to have this layer behave more like the survey layer, which
   // renders some summary data and reacts to models.
   module.exports = Backbone.View.extend({
+    template: _.template(template),
+
+    state: 'active',
+    className: 'layer',
+
+    events: {
+      'click .toggle-layer': 'toggleLayer'
+    },
 
     initialize: function(options) {
+      _.bindAll(this, 'render');
+
       this.mapView = options.mapView;
       this.dataQuery = options.layer.dataQuery;
       this.layerOptions = options.layer;
 
+      this.state = this.layerOptions.state || 'active';
+
       var self = this;
-      
+
+      // Now we need to start loading the tiles
       Promise.resolve($.ajax({
         url: 'https://localdata.cartodb.com/api/v1/map',
         type: 'GET',
         dataType: 'jsonp',
         data: {
-          stat_tag: options.layer.stat_tag,
+          stat_tag: options.layer.stat_tag, // doesn't seem to be required
           config: JSON.stringify(options.layer.config)
         }
       })).then(function (data) {
+
         // Add image tiles
         var url = 'https://' + data.cdn_url.https +
             '/localdata/api/v1/map/' + data.layergroupid +
             '/{z}/{x}/{y}.png';
-        self.mapView.addTileLayer(L.tileLayer(url));
+        this.tileLayer = L.tileLayer(url);
+
+        if (this.state === 'active') {
+          self.mapView.addTileLayer(this.tileLayer);
+        }
+
+        // We can skip adding the UTF grids on purely informational layers.
+        if(this.layerOptions.config.disableGrid) {
+          return;
+        }
 
         // Add grid
         var gridUrl = 'https://' + data.cdn_url.https +
-            '/localdata/api/v1/map/' + data.layergroupid + 
+            '/localdata/api/v1/map/' + data.layergroupid +
             '/0/{z}/{x}/{y}.grid.json?callback={cb}';
-        var gridLayer = new L.UtfGrid(gridUrl, {
+        this.gridLayer = new L.UtfGrid(gridUrl, {
           resolution: 4
         });
-        self.mapView.addGridLayer(gridLayer);
-        gridLayer.on('click', self.handleGridClick, self);
-      }).catch(function (error) {
+
+        if (this.state === 'active') {
+          self.mapView.addGridLayer(this.gridLayer);
+        }
+
+        this.gridLayer.on('click', self.handleGridClick, self);
+
+      }.bind(this)).catch(function (error) {
         console.log('Failed to fetch cartodb map config', error);
       });
+
+    },
+
+    render: function () {
+      if (this.layerOptions.noLegend) {
+        return;
+      }
+
+      var context = {
+        name: this.layerOptions.layerName,
+        meta: {
+          color: this.layerOptions.color
+        }
+      };
+
+      if (this.state === 'inactive') {
+        this.$el.addClass('legend-inactive');
+      }
+
+      this.trigger('rendered', this.$el);
+
+      this.$el.html(this.template(context));
+      return this.$el;
+    },
+
+    toggleLayer: function () {
+      console.log("Toggling layer, start state", this.state);
+      if (this.state === 'active') {
+        this.state = 'inactive';
+        this.mapView.removeTileLayer(this.tileLayer);
+
+        if(this.gridLayer) {
+          this.mapView.removeGridLayer(this.gridLayer);
+        }
+
+        this.$el.addClass('legend-inactive');
+      } else if (this.state === 'inactive') {
+        this.state = 'active';
+        this.mapView.addTileLayer(this.tileLayer);
+
+        if(this.gridLayer) {
+          this.mapView.addGridLayer(this.gridLayer);
+        }
+
+        this.$el.removeClass('legend-inactive');
+      }
     },
 
     handleGridClick: function (event) {

--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -50,6 +50,7 @@ define(function (require) {
 
     // active, inactive
     state: 'active',
+    className: 'layer',
 
     events: {
       'click .close': 'close',
@@ -57,7 +58,6 @@ define(function (require) {
       'click .show-settings .title': 'showSettings'
     },
 
-    className: 'layer',
     initialize: function(options) {
       _.bindAll(this,
         'render',

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -98,29 +98,93 @@ define(function(require, exports, module) {
           })
         ]
       }],
-      foreignInteractive: [{
-        type: 'cartodb',
-        dataQuery: 'select usedesc, property_2, propertyow, ST_AsGeoJSON(ST_Centroid(the_geom)) AS centroid from (select * from allegheny_assessed_parcels) as _cartodbjs_alias where cartodb_id = <%= cartodb_id %>',
-        humanReadableField: 'property_2',
-        fieldNames: {
-          usedesc: 'Use',
-          propertyow: 'Property Owner'
+
+      // Foreign layers
+      foreignInteractive: [
+
+        // Use and property info from Carto
+        {
+          type: 'cartodb',
+          noLegend: true,
+          dataQuery: 'select usedesc, property_2, propertyow, ST_AsGeoJSON(ST_Centroid(the_geom)) AS centroid from (select * from allegheny_assessed_parcels) as _cartodbjs_alias where cartodb_id = <%= cartodb_id %>',
+          humanReadableField: 'property_2',
+          fieldNames: {
+            usedesc: 'Use',
+            propertyow: 'Property Owner'
+          },
+          config: {
+            version: '1.0.1',
+            stat_tag:'c8c949c0-7ce7-11e4-a232-0e853d047bba',
+            layers:[{
+              type:'cartodb',
+              options:{
+                sql: 'select * from allegheny_assessed_parcels',
+                cartocss: '/** category visualization */ #allegheny_assessed_parcels { polygon-opacity: 0.3; line-color: #FFF; line-width: 1; line-opacity: 0.7; }\n #allegheny_assessed_parcels[usecode!=100] { polygon-fill: #dddddd; }\n #allegheny_assessed_parcels[usecode=100] { polygon-fill: #101010; polygon-opacity: 0.6; }\n #allegheny_assessed_parcels { polygon-fill: #DDDDDD; }',
+                cartocss_version: '2.1.1',
+                interactivity: ['cartodb_id']
+              }
+            }]
+          },
+          layerId: 'b7860d2e2bc29ae2702f611e2044284a:1418115328687.24'
         },
-        config: {
-          version: '1.0.1',
-          stat_tag:'c8c949c0-7ce7-11e4-a232-0e853d047bba',
-          layers:[{
-            type:'cartodb',
-            options:{
-              sql: 'select * from allegheny_assessed_parcels',
-              cartocss: '/** category visualization */ #allegheny_assessed_parcels { polygon-opacity: 0.3; line-color: #FFF; line-width: 1; line-opacity: 0.7; }\n #allegheny_assessed_parcels[usecode!=100] { polygon-fill: #dddddd; }\n #allegheny_assessed_parcels[usecode=100] { polygon-fill: #101010; polygon-opacity: 0.6; }\n #allegheny_assessed_parcels { polygon-fill: #DDDDDD; }',
-              cartocss_version: '2.1.1',
-              interactivity: ['cartodb_id']
-            }
-          }]
+
+        // Static council districts
+        {
+          type: 'cartodb',
+          layerName: 'Pittsburgh Council Districts',
+          color: '#ffad00',
+          dataQuery: 'select * from pittsburgh_council_districts_2012 as _cartodbjs_alias',
+          humanReadableField: 'council',
+          // fieldNames: {
+          //   usedesc: 'Use',
+          //   propertyow: 'Property Owner'
+          // },
+          config: {
+            version: '1.0.1',
+            stat_tag: '', // 'c8c949c0-7ce7-11e4-a232-0e853d047bba',
+            disableGrid: true,
+            layers:[{
+              type:'cartodb',
+              options:{
+                sql: 'select * from pittsburgh_council_districts_2012',
+                cartocss: "/** simple visualization */  #pittsburgh_council_districts_2012{   polygon-fill: #FF6600;   polygon-opacity: 0;   line-color: #ffad00;   line-width: 2.5;   line-opacity: 1; }  #pittsburgh_council_districts_2012::labels {   text-name: [council];   text-face-name: 'Open Sans Regular';   text-size: 16;   text-label-position-tolerance: 0;   text-fill: #45403e;   text-halo-fill: #FFF;   text-halo-radius: 2.5;   text-dy: -15;   text-allow-overlap: true;   text-placement: point;   text-placement-type: dummy; }",
+                cartocss_version: '2.1.1'
+                // interactivity: ['cartodb_id']
+              }
+            }]
+          },
+          layerId: 'pittsburgh-council-districts'
         },
-        layerId: 'b7860d2e2bc29ae2702f611e2044284a:1418115328687.24'
-      }]
+
+        // Static neighborhood bounds
+        {
+          type: 'cartodb',
+          layerName: 'Pittsburgh Neighborhoods',
+          state: 'inactive',
+          color: '#ffad00',
+          dataQuery: 'select * from pittsburgh_neighborhoods as _cartodbjs_alias',
+          humanReadableField: 'neighborhood',
+          // fieldNames: {
+          //   usedesc: 'Use',
+          //   propertyow: 'Property Owner'
+          // },
+          config: {
+            version: '1.0.1',
+            stat_tag: '', // 'c8c949c0-7ce7-11e4-a232-0e853d047bba',
+            disableGrid: true,
+            layers:[{
+              type:'cartodb',
+              options:{
+                sql: 'select * from pittsburgh_neighborhoods',
+                cartocss: "/** simple visualization */  #pittsburgh_neighborhoods{   polygon-fill: #FF6600;   polygon-opacity: 0;   line-color: #ffad00;   line-width: 2.5;   line-opacity: 1; }  #pittsburgh_neighborhoods::labels {   text-name: [neighborhood];   text-face-name: 'Open Sans Regular';   text-size: 12;   text-label-position-tolerance: 0;   text-fill: #45403e;   text-halo-fill: #FFF;   text-halo-radius: 1.5;   text-dy: -10;   text-allow-overlap: true;   text-placement: point;   text-placement-type: dummy; } ",
+                cartocss_version: '2.1.1'
+                // interactivity: ['cartodb_id']
+              }
+            }]
+          },
+          layerId: 'pittsburgh-neighborhoods'
+        }
+      ]
     },
 
     // WALKSCOPE -----------------------------------------------------------------

--- a/src/js/views/surveys/multi.js
+++ b/src/js/views/surveys/multi.js
@@ -100,6 +100,10 @@ define(function(require, exports, module) {
       this.$el.find('.layers').append($el);
     },
 
+    appendStatic: function ($el) {
+      this.$el.find('.static-layers').append($el);
+    },
+
     appendSettings: function($el) {
       // XXX TODO
       // Set up a container for each datasource + id so we know exactly
@@ -132,13 +136,19 @@ define(function(require, exports, module) {
 
       // Render foreign data layers
       var mapView = this.mapView;
+
       if (this.project.foreignInteractive) {
         this.foreignLayers = _.map(this.project.foreignInteractive, function (layer, i) {
           if (layer.type === 'cartodb') {
+
             var view = new CartoDBLayer({
               mapView: mapView,
               layer: layer
             });
+
+            // Render the nav
+            this.listenTo(view, 'rendered', this.appendStatic);
+            view.render();
 
             // Hook item-selection up to the info window.
             this.listenTo(view, 'itemSelected', function (data) {


### PR DESCRIPTION
![screen shot 2015-01-07 at 10 59 51 am](https://cloud.githubusercontent.com/assets/86435/5648505/11dbd108-965d-11e4-8a0d-e4030638eb3b.png)

Also adds a couple params for foreign layers:

- `noLegend: true` -- don't show the layerControl
- `disableGrid: true` -- don't add a UTF grid
- `state: 'inactive'` -- The layer starts "turned off". Renders the control, but doesn't add the layer to the map