### PR TITLE
Use the same legend interface on projects and surveys

### DIFF
--- a/src/css/sass/components.scss
+++ b/src/css/sass/components.scss
@@ -112,7 +112,7 @@
   position: absolute;
   left: 0px;
   top: 0px;
-  padding: 20px 20px 0 20px;
+  padding: 20px 20px 10px 20px;
   background: white;
   width: 340px;
 

--- a/src/css/sass/components/filters.scss
+++ b/src/css/sass/components/filters.scss
@@ -29,9 +29,12 @@
     display: inline-block;
     vertical-align: top;
 
+    line-height: 1em;
+
     width: 20%;
     padding: 1%;
     margin-right: 2%;
+    margin-top: 0.5em;
     min-height: 50px;
     border-top: 4px solid $thinpink;
 
@@ -68,6 +71,26 @@
   .answers button {
     margin-top: 10px;
   }
+}
+
+.selected-filters {
+  h3 {
+    font-size: 24px;
+    margin-bottom: 0;
+  }
+}
+
+/* Styles shared between the legend and the filters */
+.legend,
+.filters {
+  a.clear {
+    color: $body-med;
+  }
+
+  .question-title:hover,
+  span.answer:hover {
+    color: $blue;
+  }
 
   .answer {
     display: block;
@@ -78,10 +101,11 @@
   }
 
   .circle {
-    border-radius: 9px;
+    border: 3px solid;
+    border-radius: 14px;
     display: inline-block;
-    height: 18px;
-    width: 18px;
+    height: 14px;
+    width: 14px;
     margin-bottom: -3px;
   }
 
@@ -95,7 +119,7 @@
 
     .circle {
       background: #6e6663;
-      display: block;
+      display: inline-block;
     }
 
     .answers button {
@@ -108,13 +132,12 @@
   }
 }
 
-.selected-filters {
-  h3 {
-    font-size: 24px;
-    margin-bottom: 0;
+.legend {
+  .question-title {
+    cursor: pointer;
+    font-family: $bold;
   }
 }
-
 
 /**
  * Filters in projects.
@@ -128,4 +151,25 @@
 }
 
 
+.legend-active .circle {
+  background-color: transparent !important;
+}
 
+.inactive .circle {
+  background-color: transparent !important;
+  border-color: transparent !important;
+}
+
+.legend-inactive {
+    .selected {
+      display: none;
+    }
+
+    .deselected {
+      display: inline-block;
+    }
+
+    .legend {
+      display: none;
+    }
+  }

--- a/src/css/sass/components/projects.scss
+++ b/src/css/sass/components/projects.scss
@@ -55,18 +55,6 @@
       line-height: 1em;
     }
 
-    .circle {
-      border: 3px solid;
-      border-radius: 14px;
-      display: inline-block;
-      height: 14px;
-      width: 14px;
-      margin-bottom: -3px;
-    }
-
-    .legend-active .circle {
-      background-color: transparent !important;
-    }
 
     /* Checkboxes / hide-show control for layer */
     .selected {
@@ -77,35 +65,12 @@
       display: none;
     }
 
-    .inactive .circle {
-      background-color: transparent !important;
-      border-color: transparent !important;
-    }
-
-    .question {
-      line-height: 1em;
-      margin-top: 0.5em;
-    }
-
+    /*
     .answer {
       display: block;
       cursor: pointer;
       line-height: 27px;
-    }
-  }
-
-  .layer.legend-inactive {
-    .selected {
-      display: none;
-    }
-
-    .deselected {
-      display: inline-block;
-    }
-
-    .legend {
-      display: none;
-    }
+    }*/
   }
 
   .static-layers {
@@ -158,28 +123,10 @@
     }
   }
 
+  /* Hide the date filters on project views (for now) */
   .filters {
     .date-filters {
       display: none;
-    }
-  }
-
-  .legend {
-    .question-title {
-      cursor: pointer;
-      font-family: $bold;
-    }
-  }
-
-  .legend,
-  .filters {
-    a.clear {
-      color: $body-med;
-    }
-
-    .question-title:hover,
-    span.answer:hover {
-      color: $blue;
     }
   }
 

--- a/src/js/templates/filters/filters.html
+++ b/src/js/templates/filters/filters.html
@@ -1,8 +1,16 @@
-
 <div class="filters">
   <div class="filters-in">
-        <button href="" class="button mini flex close"><i class="fa fa-chevron-left"></i> Back to the map</button>
-        <button href="" class="button mini flex clear">Clear filters</button>
+
+    <div class="toolbar">
+      <h2>Layer controls</h2>
+      <button href="" class="close-settings button mini flex"><i class="fa fa-times"></i> Close</button>
+      <button href="" class="button mini flex clear">Clear</button>
+    </div>
+
+<!--     <button href="" class="button mini flex close"><i class="fa fa-chevron-left"></i> Back to the map</button>
+    <button href="" class="button mini flex clear">Clear filters</button>
+ -->
+
     <div class="date-filters filter">
       <h3>
         Filter by date
@@ -20,3 +28,4 @@
     <div class="question-filters filter"></div>
   </div>
 </div>
+

--- a/src/js/templates/filters/question-filters.html
+++ b/src/js/templates/filters/question-filters.html
@@ -2,24 +2,25 @@
 
   <h3>Filter by question</h3>
 
+  <div class="options">
   <% _.each(_.keys(questions), function (name) {%>
     <% if(! _.has(questions, name)) { return; } %>
-
     <div class="question" data-question="<%- name %>">
-      <label>
-        <%- questions[name].text %>
-      </label>
+      <span class="question-title"><%- questions[name].text %></span>
+      <span class="toggle"><i class="fa fa-angle-down"></i></span>
 
       <div class="answers">
         <% _.each(questions[name].answers, function (answer) {%>
           <div class="answer" data-answer="<%- answer.value %>" data-question="<%- name %>">
-            <div class="circle" style="background-color: <%- answer.color %>;"></div>
+            <div class="circle" style="background-color: <%- answer.color %>; border-color: <%- answer.color %>"></div>
             <div class="print circle" style="border-color:<%- answer.color %>;"></div>
-            <%- answer.text %> <%- answer.count %>
+            <%- answer.text %> (<%- answer.count %>)
           </div>
         <% }); %>
       </div>
-
     </div>
+
   <% }); %>
+  </div>
+
 </div>

--- a/src/js/templates/projects/surveys/legend.html
+++ b/src/js/templates/projects/surveys/legend.html
@@ -1,11 +1,12 @@
 <div class="question" data-question="<%- filters.question %>">
   <span class="question-title">
-    <%- category.name %> <a href="#" class="clear"><i class="fa fa-times"></i></a>
+    <%- category.text %>
+    <!--<a href="#" class="clear"><i class="fa fa-times"></i></a>-->
   </span>
 
   <div class="answers">
     <% _.each(category.values, function (value) {%>
-      <span class="answer" data-answer="<%- value.text %>" data-question="<%- category.name %>">
+      <span class="answer <% if(filters.answer && (filters.answer !== value.value)) { %> inactive<% } %>" data-answer="<%- value.value || value.name %>" data-question="<%- category.name %>">
         <span class="circle" style="background-color: <%- value.color %>; border-color: <%- value.color %>;"></span>
         <%- value.text %>
       </span>

--- a/src/js/templates/projects/surveys/settings-survey.html
+++ b/src/js/templates/projects/surveys/settings-survey.html
@@ -19,7 +19,6 @@
 
     <div class="question-filters filter"></div>
     <div class="questions">
-      <!-- <strong class="clear">Show all repsonses</strong>-->
 
       <h3>Select a question to explore</h3>
 
@@ -33,7 +32,7 @@
 
           <div class="answers">
             <% _.each(category.values, function (value) {%>
-              <span class="answer" data-answer="<%- value.text %>" data-question="<%- category.name %>">
+              <span class="answer" data-answer="<%- value.name %>" data-question="<%- category.name %>">
                 <span class="circle" style="background-color: <%- value.color %>; border-color: <%- value.color %>;"></span>
                 <%- value.text %>
               </span>

--- a/src/js/templates/surveys/layerFilter.html
+++ b/src/js/templates/surveys/layerFilter.html
@@ -6,8 +6,6 @@
   </div>
 
   <div class="questions">
-    <!-- <strong class="clear">Show all repsonses</strong>-->
-
     <div class="select">Select a question</div>
 
     <div class="options">
@@ -20,14 +18,12 @@
         <div class="answers">
           <% _.each(questions[name].answers, function (answer) {%>
             <div class="answer" data-answer="<%- answer.value %>" data-question="<%- name %>">
-              <div class="circle" style="background-color: <%- answer.color %>;"></div>
+              <div class="circle" style="background-color: <%- answer.color %>; border-color: <%- answer.color %>;"></div>
               <div class="print circle" style="border-color:<%- answer.color %>;"></div>
               <%- answer.text %> (<%- answer.count %>)
             </div>
           <% }); %>
         </div>
-      </div>
-
     <% }); %>
     </div>
   </div>

--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -146,7 +146,7 @@ define(function (require) {
         var filterDefs = _.find(this.exploration, {
           name: filter.question
         }).values;
-        data = _.find(filterDefs, { text: filter.answer }).layer;
+        data = _.find(filterDefs, { name: filter.answer }).layer;
       }
 
       // Get TileJSON

--- a/src/js/views/responses/responses.js
+++ b/src/js/views/responses/responses.js
@@ -248,7 +248,7 @@ define(function(require, exports, module) {
 
       // Hide the deep dive controls.
       $('.control-pane').hide();
-      $('#filter-view-container').hide();
+      $('.filters').hide();
       if (this.selectedItemListView) {
         this.selectedItemListView.remove();
         this.selectedItemListView = null;
@@ -314,6 +314,7 @@ define(function(require, exports, module) {
     }
 
   });
+
 
   /*
    * Map-oriented view for embedded pages.

--- a/src/js/views/surveys/legend.js
+++ b/src/js/views/surveys/legend.js
@@ -1,0 +1,99 @@
+/*jslint nomen: true */
+/*globals define */
+
+define(function (require) {
+  'use strict';
+
+  var $ = require('jquery');
+  var _ = require('lib/lodash');
+  var Backbone = require('backbone');
+
+  // LocalData
+  var settings = require('settings');
+
+  // Templates
+  var template = require('text!templates/projects/surveys/legend.html');
+
+  var LegendView = Backbone.View.extend({
+    className: 'legend',
+    filters: {},
+
+    template: _.template(template),
+
+    events: {
+      "click .question-title": "selectQuestion",
+      "click .answer": "selectAnswer"
+    },
+
+    initialize: function(options) {
+      _.bindAll(this, 'render', 'reset');
+
+      this.filters = options.filters;
+      this.category = options.category;
+
+      console.log("Init legend with options", options);
+
+      // We alias answers to values to make this view more generic
+      // (useful in the projects view)
+      if (this.category.answers) {
+        this.category.values = this.category.answers;
+      }
+      if (!this.category.text) {
+        this.category.text = this.filters.question;
+      }
+
+    },
+
+    render: function() {
+      var context = {
+        category: this.category,
+        filters: this.filters
+      };
+      this.$el.html(this.template(context));
+      return this.$el;
+    },
+
+    /**
+     * Reset any filters
+     */
+    reset: function(event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      this.trigger('filterReset');
+    },
+
+    selectQuestion: function(event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      // TODO
+      // Pass the question instead of the event?`
+      // var $question = $(event.target).parent();
+      // var question = $question.attr('data-question');
+
+      this.trigger('questionSelected', event);
+    },
+
+    /**
+     * Show only responses with a specific answer
+     */
+    selectAnswer: function(event) {
+      if (event) {
+        event.preventDefault();
+      }
+
+      // TODO
+      // Pass the answer instead of the event?
+      // var $answer = $(event.target);
+      // var answer = $answer.attr('data-answer');
+
+      this.trigger('answerSelected', event);
+    }
+
+  });
+
+  return LegendView;
+});


### PR DESCRIPTION
Creates a new `LegendView` that is used by both projects and surveys. It's got some dark corners -- since the two use different naming and data structures, compromises were necessary. 

A next step refactor would make a view for each question in the filter, which would then also replace the legend. 