### PR TITLE
Fix an issue where carto grids wouldn't be added at far zooms

### DIFF
--- a/src/js/views/maps/cartodb-layer.js
+++ b/src/js/views/maps/cartodb-layer.js
@@ -108,7 +108,7 @@ define(function (require, exports, module) {
         });
 
         if (this.state === 'active') {
-          self.mapView.addGridLayer(this.gridLayer);
+          self.mapView.addGridLayer(this.gridLayer, true);
         }
 
         this.gridLayer.on('click', self.handleGridClick, self);
@@ -157,7 +157,7 @@ define(function (require, exports, module) {
         this.mapView.addTileLayer(this.tileLayer);
 
         if(this.gridLayer) {
-          this.mapView.addGridLayer(this.gridLayer);
+          this.mapView.addGridLayer(this.gridLayer, true);
         }
 
         this.$el.removeClass('legend-inactive');

--- a/src/js/views/maps/multi-map.js
+++ b/src/js/views/maps/multi-map.js
@@ -75,12 +75,12 @@ define(function(require, exports, module) {
       this.map.removeLayer(layer);
     },
 
-    addGridLayer: function (layer) {
+    addGridLayer: function (layer, alwaysAddGrid) {
       // Make sure the grid layer is on top.
-      if (this.map.getZoom() >= MIN_GRID_ZOOM) {
-
+      if (alwaysAddGrid) {
         this.map.addLayer(layer);
-        // layer.on('click', this.selectObject);
+      } else if (this.map.getZoom() >= MIN_GRID_ZOOM) {
+        this.map.addLayer(layer);
       }
     },
 


### PR DESCRIPTION
I could do this as an options object (it's a bit mystery meat) but this does the trick