### PR TITLE
Let the control pane shrink when there's less content

### DIFF
--- a/src/css/sass/components.scss
+++ b/src/css/sass/components.scss
@@ -123,7 +123,10 @@
   top: 0px;
   padding: 20px 20px 10px 20px;
   background: white;
-  width: 340px;
+  max-width: 340px;
+  border-style: solid;
+  border-width: 0 5px 5px 0;
+  border-color: $thinpink;
 
   button {
     display: block;


### PR DESCRIPTION
Also adds a subtle border in the same style used for responses and filters to distinguish the box from the map (addresses #509)

![screen shot 2015-02-12 at 12 48 57 pm](https://cloud.githubusercontent.com/assets/86435/6173398/c9bbca7a-b2b5-11e4-9b16-01da0fa174cc.png)
