### PR TITLE
Add a subtle loading indicator to reports page

### DIFF
--- a/src/css/sass/components/projects.scss
+++ b/src/css/sass/components/projects.scss
@@ -162,11 +162,8 @@
   }
 
   #stats-view-container {
-    position: absolute;
     background: #fff;
-    width: 80%;
-    left: 10%;
-    top: 20px;
+    margin: 20px 2%;
 
     .report {
       margin-bottom: 3%;

--- a/src/css/sass/utils.scss
+++ b/src/css/sass/utils.scss
@@ -131,8 +131,8 @@ $bold: "Neuzeit Office W01 Bold", Helvetica Neue, Helvetica, sans-serif;
 }
 
 .spinner {
-  width: 20px;
-  height: 20px;
+  width: 50px;
+  height: 50px;
   margin: 0px auto;
   background-color: $thinpink;
 

--- a/src/js/templates/projects/reports.html
+++ b/src/js/templates/projects/reports.html
@@ -1,6 +1,8 @@
 <div class="out map-list-view multi">
   <div id="stats-view-container">
-    <div class="stats-container"></div>
+    <div class="stats-container">
+      <div class="spinner"></div>
+    </div>
     <div class="exports-container"></div>
   </div>
 </div>

--- a/src/js/templates/projects/surveys/stats-survey.html
+++ b/src/js/templates/projects/surveys/stats-survey.html
@@ -6,11 +6,10 @@
     </div>
 
     <div class="piece">
-        <h4 class="inset">Contributors over time</h4>
+        <h4 class="inset">Contributions over time</h4>
         <div class="activity" id="<%= activityId %>"></div>
     </div>
 
     <div class="graphs">
-
     </div>
 </div>

--- a/src/js/views/projects/reports.js
+++ b/src/js/views/projects/reports.js
@@ -46,6 +46,7 @@ define(function(require, exports, module) {
     },
 
     appendStats: function($el) {
+      this.$el.find('.stats-container .spinner').hide();
       this.$el.find('.stats-container').append($el);
     },
 


### PR DESCRIPTION
Currently a pulsing circle (5th one here http://tobiasahlin.com/spinkit/) in our $thinpink color. 

Also expands width of reports page so clients have more flexibility on how it's displayed. 