### PR TITLE
Let projects specify display of questions in the item view

### DIFF
--- a/src/css/sass/components/surveys.scss
+++ b/src/css/sass/components/surveys.scss
@@ -148,6 +148,22 @@
     border-top: 4px solid $thinpink;
     margin-top: 10px;
 
+    .answer {
+      margin-bottom: 0.75em;
+      line-height: 1em;
+
+      .key,
+      .value {
+        display: block;
+      }
+
+      .value {
+        font-family: $bold;
+      }
+    }
+
+
+
     .response-tools {
 
       /* Potential toolbar styling

--- a/src/js/templates/responses/item.html
+++ b/src/js/templates/responses/item.html
@@ -27,53 +27,52 @@
 
 
 <div class="answers">
+  <% if (exploration && surveyOptions.explorationControlsItem) { %>
+    <% _.each(exploration, function(e) { %>
+      <% if (r.responses[e.question]) { %>
+        <div class="answer">
+          <div class="key"><%= e.name %></div>
+          <% _.each(e.values, function(v) { %>
+            <% if (v.name === r.responses[e.question]) { %>
+              <div class="value"><%= v.text %></div>
+            <% } %>
+          <% }); %>
+        </div>
+      <% } %>
+    <% }); %>
+  <% } else { %>
+    <% _.each(_.keys(r.responses).reverse(), function(key) { var resp = r.responses[key]; %>
+      <div class="answer">
+        <span class="key">
+          <% if(labels[key]) { %>
+            <%- labels[key] %>
+          <% } else { %>
+            <%- key %>
+          <% } %>
+        </span>
+        <span class="value"><strong>
+          <% if (_.has(answerLabels, key) && _.has(answerLabels[key], resp)) { %>
+            <%- answerLabels[key][resp] %>
+          <% } else { %>
+            <%- resp %>
+          <% } %>
+        </strong></span>
 
-<% _.each(exploration, function(e) { %>
-  <% if (r.responses[e.question]) { %>
-    <div class="answer">
-      <div class="key"><%= e.name %></div>
-      <% _.each(e.values, function(v) { %>
-        <% if (v.name === r.responses[e.question]) { %>
-          <div class="value"><%= v.text %></div>
-        <% } %>
-      <% }); %>
-    </div>
+        <select class="edit" data-question="<%- key %>">
+          <% if (form[key]) { %>
+            <% _.each(form[key].answers, function(answer) { %>
+              <option
+                value="<%- answer.value %>"
+                <% if (answer.value === resp) { %> selected="selected" <% } %>>
+                <%- answer.text %>
+              </option>
+            <% }); %>
+          <% } %>
+        </select>
+
+      </div>
+    <% }); %>
   <% } %>
-<% }); %>
-</div>
-
-<!--
-<% _.each(_.keys(r.responses).reverse(), function(key) { var resp = r.responses[key]; %>
-  <div class="answer">
-    <span class="key">
-      <% if(labels[key]) { %>
-        <%- labels[key] %>
-      <% } else { %>
-        <%- key %>
-      <% } %>
-    </span>
-    <span class="value"><strong>
-      <% if (_.has(answerLabels, key) && _.has(answerLabels[key], resp)) { %>
-        <%- answerLabels[key][resp] %>
-      <% } else { %>
-        <%- resp %>
-      <% } %>
-    </strong></span>
-
-    <select class="edit" data-question="<%- key %>">
-      <% if (form[key]) { %>
-        <% _.each(form[key].answers, function(answer) { %>
-          <option
-            value="<%- answer.value %>"
-            <% if (answer.value === resp) { %> selected="selected" <% } %>>
-            <%- answer.text %>
-          </option>
-        <% }); %>
-      <% } %>
-    </select>
-
-  </div>
-<% }); %>
 </div>
 
 <% if (surveyOptions.loggedIn) { %>
@@ -107,4 +106,3 @@
   <div class="error">Sorry, there was a problem deleting this record</div>
 </div>
 <% } %>
--->

--- a/src/js/templates/responses/item.html
+++ b/src/js/templates/responses/item.html
@@ -27,6 +27,22 @@
 
 
 <div class="answers">
+
+<% _.each(exploration, function(e) { %>
+  <% if (r.responses[e.question]) { %>
+    <div class="answer">
+      <div class="key"><%= e.name %></div>
+      <% _.each(e.values, function(v) { %>
+        <% if (v.name === r.responses[e.question]) { %>
+          <div class="value"><%= v.text %></div>
+        <% } %>
+      <% }); %>
+    </div>
+  <% } %>
+<% }); %>
+</div>
+
+<!--
 <% _.each(_.keys(r.responses).reverse(), function(key) { var resp = r.responses[key]; %>
   <div class="answer">
     <span class="key">
@@ -91,3 +107,4 @@
   <div class="error">Sorry, there was a problem deleting this record</div>
 </div>
 <% } %>
+-->

--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -234,6 +234,7 @@ define(function (require) {
         objectId: objectId
       });
 
+      console.log("Selecting item with explroation", this.exploration);
       var surveyOptions = this.survey.get('surveyOptions') || {};
       this.selectedItemListView = new ObjectView({
         id: 'responses-list',
@@ -241,7 +242,8 @@ define(function (require) {
         labels: this.forms.getQuestions(),
         forms: this.forms,
         surveyOptions: surveyOptions,
-        survey: this.survey
+        survey: this.survey,
+        exploration: this.exploration
       });
 
       this.trigger('itemSelected', {

--- a/src/js/views/projects/datalayers/survey/object-view.js
+++ b/src/js/views/projects/datalayers/survey/object-view.js
@@ -33,6 +33,7 @@ define(function (require) {
       this.surveyOptions = options.surveyOptions;
       this.surveyId = options.surveyId;
       this.objectId = options.objectId;
+      this.exploration = options.exploration;
     },
 
     remove: function() {
@@ -77,7 +78,8 @@ define(function (require) {
           model: response,
           labels: this.labels,
           forms: this.forms,
-          surveyOptions: this.surveyOptions
+          surveyOptions: this.surveyOptions,
+          exploration: this.exploration
         });
         this.$el.append(item.render().el);
       }, this);

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -147,7 +147,7 @@ define(function(require, exports, module) {
       baselayer: '//a.tiles.mapbox.com/v3/matth.kmf6l3h1/{z}/{x}/{y}.png',
       location: 'Gary, IN',
       center: [-87.346427, 41.59337],
-      zoom: 13,
+      zoom: 18,
       scrollWheelZoom: false,
       surveys: [{
         layerName: 'Parcels surveyed',

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -147,7 +147,7 @@ define(function(require, exports, module) {
       baselayer: '//a.tiles.mapbox.com/v3/matth.kmf6l3h1/{z}/{x}/{y}.png',
       location: 'Gary, IN',
       center: [-87.346427, 41.59337],
-      zoom: 18,
+      zoom: 13,
       scrollWheelZoom: false,
       surveys: [{
         layerName: 'Parcels surveyed',
@@ -155,8 +155,9 @@ define(function(require, exports, module) {
         color: '#45403e',
         options: {
           anonymous: true,
+          exploreButton: true,
           hideCollectorNames: true,
-          exploreButton: true
+          explorationControlsItem: true
         },
         countPath: 'survey.responseCount',
         query: {},
@@ -166,6 +167,32 @@ define(function(require, exports, module) {
         },
         styles: simpleStyles({color: '#45403e'}),
         exploration: [
+          makeBasicExploration({
+            name: 'Is there a structure?',
+            question: 'structure',
+            values: [
+              'yes',
+              'no'
+            ],
+            valueNames: [
+              'Yes',
+              'No structure'
+            ],
+            colors: ['#0571b0', '#05b04c']
+          }),
+          makeBasicExploration({
+            name: 'Occupancy',
+            question: 'vacant-abandoned',
+            values: [
+              'occupied-structure',
+              'vacant-abandoned-structure'
+            ],
+            valueNames: [
+              'Occupied',
+              'Vacant'
+            ],
+            colors: ['#0571b0', '#f46d31']
+          }),
           makeBasicExploration({
             name: 'Property condition',
             question: 'structure-grade',
@@ -186,32 +213,6 @@ define(function(require, exports, module) {
             colors: ['#0571b0', '#92c5de', '#d3d3d3', '#f46d31', '#ca0020']
             // purples:
             // colors: ['#05b04c', '#a5e76b', '#d3d3d3', '#d791da', '#85048a']
-          }),
-          makeBasicExploration({
-            name: 'Lots with structures',
-            question: 'structure',
-            values: [
-              'yes',
-              'no'
-            ],
-            valueNames: [
-              'Structure',
-              'No structure'
-            ],
-            colors: ['#0571b0', '#05b04c']
-          }),
-          makeBasicExploration({
-            name: 'Occupancy',
-            question: 'vacant-abandoned',
-            values: [
-              'occupied-structure',
-              'vacant-abandoned-structure'
-            ],
-            valueNames: [
-              'Occupied',
-              'Vacant'
-            ],
-            colors: ['#0571b0', '#f46d31']
           }),
           makeBasicExploration({
             name: 'Structural condition',
@@ -243,14 +244,16 @@ define(function(require, exports, module) {
           // }),
           makeBasicExploration({
             name: 'Parking lot',
-            question: 'enclosed-secure',
+            question: 'parking-lot',
             values: [
-              'yes'
+              'yes',
+              'no'
             ],
             valueNames: [
-              'Parking lots'
+              'Yes',
+              'No'
             ],
-            colors: ['#0571b0']
+            colors: ['#0571b0', '#535353']
           }),
           makeBasicExploration({
             name: 'Residential use structures',
@@ -259,7 +262,7 @@ define(function(require, exports, module) {
               'yes'
             ],
             valueNames: [
-              'Residential'
+              'Yes'
             ],
             colors: ['#0571b0']
           }),
@@ -270,7 +273,7 @@ define(function(require, exports, module) {
               'yes'
             ],
             valueNames: [
-              "Commercial"
+              "Yes"
             ],
             colors: ['#0571b0']
           }),
@@ -281,7 +284,7 @@ define(function(require, exports, module) {
               'yes'
             ],
             valueNames: [
-              'Public/government'
+              'Yes'
             ],
             colors: ['#0571b0']
           })

--- a/src/js/views/responses/item.js
+++ b/src/js/views/responses/item.js
@@ -50,6 +50,8 @@ function($, _, Backbone, events, settings, api, Responses, template) {
       this.listenTo(this.model, "destroy", this.remove);
 
       this.surveyOptions = options.surveyOptions || {};
+      console.log("Opening item with exploration", options);
+      this.exploration = options.exploration;
       this.labels = options.labels;
       this.forms = options.forms;
     },
@@ -69,6 +71,8 @@ function($, _, Backbone, events, settings, api, Responses, template) {
     render: function() {
       var $el = $(this.el);
 
+      console.log("Render using exploration", this.exploration);
+
       // If this is meant for anonymous consumption, then ignore the fact
       // that the user might be logged in through the primary dashboard.
       // TODO: If the entire interface is meant for anonymous consumption,
@@ -84,7 +88,8 @@ function($, _, Backbone, events, settings, api, Responses, template) {
         labels: this.labels,
         answerLabels: this.makeAnswerLabels(),
         form: this.forms.getFlattenedForm(),
-        surveyOptions: this.surveyOptions
+        surveyOptions: this.surveyOptions,
+        exploration: this.exploration
       };
 
       $el.html(this.template(options));

--- a/src/js/views/responses/list.js
+++ b/src/js/views/responses/list.js
@@ -39,7 +39,6 @@ define(function (require) {
       this.surveyId = options.surveyId;
       this.objectId = options.objectId;
 
-      console.log("Using exploration in list", options);
       this.exploration = options.exploration;
     },
 

--- a/src/js/views/responses/list.js
+++ b/src/js/views/responses/list.js
@@ -38,6 +38,9 @@ define(function (require) {
       this.surveyOptions = options.surveyOptions;
       this.surveyId = options.surveyId;
       this.objectId = options.objectId;
+
+      console.log("Using exploration in list", options);
+      this.exploration = options.exploration;
     },
 
     remove: function() {
@@ -75,7 +78,8 @@ define(function (require) {
           model: response,
           labels: this.labels,
           forms: this.forms,
-          surveyOptions: this.surveyOptions
+          surveyOptions: this.surveyOptions,
+          exploration: this.exploration
         });
         this.$el.append(item.render().el);
       }.bind(this));


### PR DESCRIPTION
Lets us hide, show, reword, and reorder questions in the projects display by setting `options. explorationControlsItem` to `true`.

Also adds a bit of spacing between responses so they scan nicely: 

![screen shot 2015-02-16 at 10 59 55 am](https://cloud.githubusercontent.com/assets/86435/6215039/fd13dd96-b5ca-11e4-9ac3-c1e467a7cb73.png)
