### PR TITLE
Show a loading indicator on project pages

### DIFF
--- a/src/css/sass/components.scss
+++ b/src/css/sass/components.scss
@@ -121,7 +121,7 @@
   position: absolute;
   left: 0px;
   top: 0px;
-  padding: 20px 20px 10px 20px;
+  padding: 20px 20px 0px 20px;
   background: white;
   max-width: 340px;
   border-style: solid;

--- a/src/css/sass/components/projects.scss
+++ b/src/css/sass/components/projects.scss
@@ -1,5 +1,9 @@
 .multi {
 
+  .spinner {
+    margin-bottom: 10px;
+  }
+
   .count {
     display: block;
   }

--- a/src/js/templates/projects/surveys/loading.html
+++ b/src/js/templates/projects/surveys/loading.html
@@ -1,0 +1,3 @@
+<div>
+  <div class="spinner"></div>
+</div>

--- a/src/js/views/surveys/multi.js
+++ b/src/js/views/surveys/multi.js
@@ -22,6 +22,7 @@ define(function(require, exports, module) {
   // Templates
   var embeddedSurveyTemplate = require('text!templates/responses/embed-multi.html');
   var layerTitleTemplate = require('text!templates/projects/surveys/layer-title.html');
+  var loadingTemplate = require('text!templates/projects/surveys/loading.html');
   var disqusTemplate = require('text!templates/disqus.html');
 
 
@@ -48,6 +49,7 @@ define(function(require, exports, module) {
 
     template: _.template(embeddedSurveyTemplate),
     layerTitleTemplate: _.template(layerTitleTemplate),
+    loadingTemplate: _.template(loadingTemplate),
     el: '#container',
 
     events: {
@@ -93,10 +95,6 @@ define(function(require, exports, module) {
         color: surveyConfig.color
       }));
 
-    },
-
-    append: function ($el) {
-      this.$el.find('.layers').append($el);
     },
 
     appendStatic: function ($el) {
@@ -191,7 +189,17 @@ define(function(require, exports, module) {
 
         this.activeLayers[survey.layerId] = surveyLayer;
 
-        this.listenTo(surveyLayer, 'rendered', this.append);
+        // Create a placeholder to fill with the layer later
+        var $surveyEl = $(this.loadingTemplate());
+        this.$el.find('.layers').append($surveyEl);
+
+        // Once we load the layer, replace the placeholder with the real content
+        this.listenTo(surveyLayer, 'rendered', function($el) {
+          $surveyEl.html($el);
+        }.bind($surveyEl));
+
+
+        // Listen to related metadata that needs to go elsewhere.
         this.listenTo(surveyLayer, 'renderedSettings', this.appendSettings);
         this.listenTo(surveyLayer, 'count', function (count) {
           this.renderCount(survey, count || 0);


### PR DESCRIPTION
Surveys that have non-trivial numbers of entries take a couple seconds to load (because we wait for all the settings -- including stats) before rendering. This PR adds a loading placeholder for each survey.

Hard to get a good screenshot for this... I should figure out how to make animated gifs

![screen shot 2015-02-16 at 12 29 01 pm](https://cloud.githubusercontent.com/assets/86435/6216359/74111268-b5d7-11e4-87eb-3a672cd90dfb.png)


