### PR TITLE
Fix a problem where settings button does not work on IE 

### DIFF
--- a/src/css/sass/components/filters.scss
+++ b/src/css/sass/components/filters.scss
@@ -151,7 +151,7 @@
 }
 
 .settings-container .filters {
-  display: initial;
+  display: inline-block;
 }
 
 .legend-active .circle {


### PR DESCRIPTION
IE does not support `display: initial`

I searched and this appears to be the only place we used it. 