### PR TITLE
Avoid fetching Survey and Forms twice

### DIFF
--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -105,7 +105,6 @@ define(function (require) {
       this.survey = new Surveys.Model({ id: this.surveyId });
       this.stats = new Stats.Model({ id: this.surveyId });
       this.forms = new Forms.Collection({ surveyId: this.surveyId });
-      this.forms.fetch({ reset: true });
 
       var self = this;
       async.parallel([
@@ -139,8 +138,6 @@ define(function (require) {
         self.render();
 
       });
-
-      this.survey.fetch();
     },
 
     update: function() {


### PR DESCRIPTION
The initializers for the survey model and forms collection both perform the type of fetch we need, so we can avoid a second, explicit fetch.