### PR TITLE
Organize api requests

### DIFF
--- a/src/js/models/responses.js
+++ b/src/js/models/responses.js
@@ -57,7 +57,11 @@ function($, _, Backbone, moment, settings, api) {
         this.limit = options.limit;
         this.filters = options.filters;
         this.sort = options.sort || 'none';
-        this.fetch();
+        this.fetch({
+          // Optionally issue a reset event instead of potentially multiple add
+          // events.
+          reset: !!options.reset
+        });
       }
     },
 

--- a/src/js/models/responses.js
+++ b/src/js/models/responses.js
@@ -56,6 +56,7 @@ function($, _, Backbone, moment, settings, api) {
         this.objectId = options.objectId;
         this.limit = options.limit;
         this.filters = options.filters;
+        this.sort = options.sort || 'none';
         this.fetch();
       }
     },
@@ -71,6 +72,8 @@ function($, _, Backbone, moment, settings, api) {
       } else {
         url = url + 'count=20&startIndex=0';
       }
+
+      url = url + '&sort=' + this.sort;
 
       if (this.filters) {
         _.each(this.filters, function(value, key){

--- a/src/js/views/responses/filter.js
+++ b/src/js/views/responses/filter.js
@@ -52,9 +52,9 @@ define(function(require, exports, module) {
       this.forms = options.forms;
       this.map = options.map;
 
-      this.stats = new Stats.Model({
+      this.stats = options.stats || (new Stats.Model({
         id: this.survey.get('id')
-      });
+      }));
       this.stats.on('change', this.render);
       this.$el.html(this.template());
 

--- a/src/js/views/responses/item.js
+++ b/src/js/views/responses/item.js
@@ -165,7 +165,10 @@ function($, _, Backbone, events, settings, util, api, Responses, template) {
 
       this.model.destroy({
         success: success,
-        error: error
+        error: error,
+        // Wait for the response before issuing the destroy event, otherwise we
+        // have a race condition.
+        wait: true,
       });
 
       util.track('survey.response.delete');

--- a/src/js/views/responses/item.js
+++ b/src/js/views/responses/item.js
@@ -81,7 +81,7 @@ function($, _, Backbone, events, settings, util, api, Responses, template) {
         this.surveyOptions.loggedIn = settings.user && settings.user.isLoggedIn();
       }
 
-      var responses = this.model.get('responses');
+      var responses = this.model.get('responses') || {};
       var form = this.forms.getMostRecentForm().getFormV2();
       var fields = [];
       var processed = {};
@@ -122,8 +122,13 @@ function($, _, Backbone, events, settings, util, api, Responses, template) {
         }
       });
 
+      var r = this.model.toJSON();
+      if (!r.responses) {
+        r.responses = {};
+      }
+
       var options = {
-        r: this.model.toJSON(),
+        r: r,
         fields: fields,
         surveyOptions: this.surveyOptions,
         exploration: this.exploration

--- a/src/js/views/responses/responses.js
+++ b/src/js/views/responses/responses.js
@@ -16,6 +16,7 @@ define(function(require, exports, module) {
 
   // Models
   var Responses = require('models/responses');
+  var Stats = require('models/stats');
 
   // Views
   var ResponseCountView = require('views/surveys/count');
@@ -76,6 +77,10 @@ define(function(require, exports, module) {
 
       this.survey = options.survey;
 
+      this.stats = options.stats || (new Stats.Model({
+        id: this.survey.get('id')
+      }));
+
       if (options.mode) {
         this.mode = options.mode;
       }
@@ -104,7 +109,8 @@ define(function(require, exports, module) {
 
       // Show collector stats
       this.collectorStatsView = new CollectorStatsView({
-        survey: this.survey
+        survey: this.survey,
+        stats: this.stats
       });
 
       // Set up the map view, now that the root exists.
@@ -123,6 +129,7 @@ define(function(require, exports, module) {
         el: $('#filter-view-container'),
         survey: this.survey,
         forms: this.forms,
+        stats: this.stats,
         map: this.mapView
       }).render();
       this.listenTo(this.filterView, 'updated', this.changeLegend);

--- a/src/js/views/surveys/stats-collector.js
+++ b/src/js/views/surveys/stats-collector.js
@@ -5,13 +5,8 @@ define(function(require, exports, module) {
   'use strict';
 
   // Libs
-  var $ = require('jquery');
   var _ = require('lib/lodash');
   var Backbone = require('backbone');
-
-  // LocalData
-  var settings = require('settings');
-  var api = require('api');
 
   // Models
   var Stats = require('models/stats');
@@ -32,11 +27,10 @@ define(function(require, exports, module) {
 
       this.survey = options.survey;
 
-      this.stats = new Stats.Model({
+      this.stats = options.stats || (new Stats.Model({
         id: this.survey.get('id')
-      });
+      }));
       this.stats.on('sync', this.render);
-      this.stats.fetch({reset: true});
     },
 
     render: function(event) {


### PR DESCRIPTION
Avoid review-related requests unless we really need them, and make cheaper requests when we do.
Pass stats around instead of making multiple requests for them.
Make the review workflow a little more robust.

/cc @hampelm 
