### PR TITLE
Fix zone save breaking settings save

### DIFF
--- a/src/js/templates/surveys/zone-editor.html
+++ b/src/js/templates/surveys/zone-editor.html
@@ -1,7 +1,7 @@
 <div class="out contrast survey-zone-editor">
   <div class="a">
     <h3>Survey zones</h3>
-    <% if(zones[0].features.length === 0) { %>
+    <% if(!zones[0] || zones[0].features.length === 0) { %>
     <p>Draw a zone on the map to get started.</p>
     <% } %>
     <div id="map-zones"></div>

--- a/src/js/views/surveys/settings.js
+++ b/src/js/views/surveys/settings.js
@@ -57,7 +57,6 @@ define(function(require, exports, module) {
       }, {});
 
       this.survey.set(fields);
-      this.survey.attributes.zones = this.mapDrawView.getZones();
       this.survey.save({}, {
         success: this.success,
         error: this.error


### PR DESCRIPTION
Fixes #581 

Basically, we were attaching leaflet layers to the zones attribute in the survey model. Backbone can't and shouldn't save them (JSON serialization problem). We used to sanitize them before saving, but when the zone editor was moved out to a new view, we lost an easy way to sanitize. 