### PR TITLE
Add a context-specific note for Pittsburgh carto layer objects

### DIFF
--- a/src/js/templates/cartodb-info.html
+++ b/src/js/templates/cartodb-info.html
@@ -8,4 +8,14 @@
     <span class="value"><strong><%- field.value %></strong></span>
   </div>
 <% }); %>
+
+
+<% if (raw.publicowne) { %>
+  <!-- gtech-specific addon -->
+  <% var cases = ['C', 'E', 'H', 'R', 'S', 'U', 'A', 'M']; %>
+  <% if ((cases.indexOf(raw.publicowne)) && raw.fairmarket === 0) { %>
+    <p style="margin-top:1em"><strong>Interested in working on this lot? <a href="http://www.lotstolove.org/your-lot/get-permission/access/">Click here for more information</a>.</strong></p>
+  <% } %>
+<% } %>
+
 </div>

--- a/src/js/views/maps/cartodb-layer.js
+++ b/src/js/views/maps/cartodb-layer.js
@@ -34,7 +34,8 @@ define(function (require, exports, module) {
       var context = {
         name: this.data[this.layerOptions.humanReadableField],
         centroid: JSON.parse(this.data.centroid),
-        googleKey: settings.GoogleKey
+        googleKey: settings.GoogleKey,
+        raw: this.data
       };
 
       var names = this.layerOptions.fieldNames;

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -382,7 +382,7 @@ define(function(require, exports, module) {
           attribution: 'Pennsylvania Spatial Data Access',
           color: '#505050',
           zIndex: 25,
-          dataQuery: "select mapblolot, usedesc, mundesc, property_2, propertyow, (case delinquent when true then 'Yes' else 'No' end) as d,  ST_AsGeoJSON(ST_Centroid(the_geom)) AS centroid, ST_AsGeoJSON(the_geom) as geom from (select * from allegheny_assessed_parcels) as _cartodbjs_alias where cartodb_id = <%= cartodb_id %>",
+          dataQuery: "select mapblolot, usedesc, mundesc, property_2, propertyow, publicowne, fairmarket, (case delinquent when true then 'Yes' else 'No' end) as d,  ST_AsGeoJSON(ST_Centroid(the_geom)) AS centroid, ST_AsGeoJSON(the_geom) as geom from (select * from allegheny_assessed_parcels) as _cartodbjs_alias where cartodb_id = <%= cartodb_id %>",
           humanReadableField: 'property_2',
           handleClick: true,
           staticLegend: '<div><i class="fa fa-square" style="color:#12b259"></i> Side Yards</div> <div><i class="fa fa-square" style="color:#101010"></i> Publicly owned</div> <div><i class="fa fa-square" style="color:#777777"></i> Privately owned</div>',


### PR DESCRIPTION
Pittsburgh needs a specific message to appear for some lots. 

This is a super hacky first take. If we need to do this twice, we should abstract this into project config. Here's a possible strategy: 

* Craft the carto query to return a boolean if the message should appear
* Add a `notes` config to the `projects` config.

```
notes: [{
   field: 'myCartoBooleanToShowMessage',
   values: [true],
   note: 'My excellent message'
}, {
   field: 'myCartoBooleanToShowMessage',
   values: [false, 'dogs'],
   note: 'Cats rule'
}]
``` 

And in the carto template, iterate over the notes and display them if the values match. 