### PR TITLE
Style MultiLineString geometries in project templates

### DIFF
--- a/src/js/templates/projects/surveys/checkbox-styles.mss
+++ b/src/js/templates/projects/surveys/checkbox-styles.mss
@@ -1,6 +1,6 @@
 Map { background-color: rgba(0,0,0,0); }
 #localdata['<%= key %>'='yes'] {
-  [GEOMETRY = LineString] {
+  [GEOMETRY = LineString],[GEOMETRY = MultiLineString] {
     line-width: 2;
     [zoom >= 15] {
       line-width: 5;
@@ -39,7 +39,7 @@ Map { background-color: rgba(0,0,0,0); }
 }
 
 #localdata['<%= key %>'!='yes'] {
-  [GEOMETRY = LineString] {
+  [GEOMETRY = LineString],[GEOMETRY = MultiLineString] {
     line-width: 2;
     [zoom >= 15] {
       line-width: 5;

--- a/src/js/templates/projects/surveys/simple-styles.mss
+++ b/src/js/templates/projects/surveys/simple-styles.mss
@@ -1,6 +1,6 @@
 Map { background-color: rgba(0,0,0,0); }
 #localdata {
-  [GEOMETRY = LineString] {
+  [GEOMETRY = LineString],[GEOMETRY = MultiLineString] {
     line-width: 2;
     [zoom >= 15] {
       line-width: 5;


### PR DESCRIPTION
We did not provide MultiLineString rules in all style templates, so those geometries would disappear in some project map views. This should apply styles consistently across LineString and MultiLineString geometries.

/cc @hampelm 