### PR TITLE
Add a print control to the map

### DIFF
--- a/src/css/sass/components.scss
+++ b/src/css/sass/components.scss
@@ -140,6 +140,26 @@
   }
 }
 
+#map .localdata-control {
+  box-shadow: 0 1px 5px rgba(0,0,0,0.4);
+  background: #fff;
+  border-radius: 5px;
+  font-family: $font;
+
+  a,
+  a:active,
+  a:hover,
+  a:visited {
+    height: 26px;
+    width: 26px;
+    line-height: 26px;
+    overflow: hidden;
+    color: black;
+    text-align: center;
+    display: block;
+  }
+}
+
 #map-tools {
   background: #fff;
   right: 70px;

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -12,7 +12,8 @@ function(L) {
 
   settings.api = {
     baseurl: '/api', // http://localhost:3000/api',
-    geo: '/api'
+    geo: '/api',
+    lascaux: 'http://lascaux.datamade.us/api'
   };
 
   settings.BingKey = 'Arc0Uekwc6xUCJJgDA6Kv__AL_rvEh4Hcpj4nkyUmGTIx-SxMd52PPmsqKbvI_ce';

--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -187,7 +187,7 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
         overlay_tiles: this.tileLayer._url,
         base_tiles: settings.printLayer,
         zoom: this.map.getZoom(),
-        dimensions: '8.5,11',
+        dimensions: '8.5,11', // default unit is inches; tiles are 150dpi
         center: this.map.getCenter().lng + ',' + this.map.getCenter().lat,
         output_format: 'pdf'
       };

--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -56,7 +56,8 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
         'fitBounds',
         'selectObject',
         'deselectObject',
-        'addTileLayer'
+        'addTileLayer',
+        'pdf'
       );
 
       this.survey = options.survey;
@@ -179,6 +180,23 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
     },
 
 
+    // Use Lascaux to create a PDF of the focused map area at the current zoom.
+    pdf: function(event) {
+      event.preventDefault();
+      var options = {
+        overlay_tiles: this.tileLayer._url,
+        base_tiles: settings.printLayer,
+        zoom: this.map.getZoom(),
+        dimensions: '8.5,11',
+        center: this.map.getCenter().lng + ',' + this.map.getCenter().lat,
+        output_format: 'pdf'
+      };
+
+      var url = settings.api.lascaux + '?' + $.param(options);
+      window.open(url);
+    },
+
+
     render: function() {
       if (this.map === null) {
         // Initialize the map
@@ -189,6 +207,25 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
         });
 
         this.map.addControl(L.control.zoom({ position: 'topright' }));
+
+
+        // Add a control to print the map
+        var PrintControl = L.Control.extend({
+            options: {
+                position: 'topright'
+            },
+
+            onAdd: function (map) {
+                var container = L.DomUtil.create('div', 'localdata-control');
+
+                $(container).html('<a>PDF</a>');
+                $(container).on('click', this.pdf);
+
+                return container;
+            }.bind({ pdf: this.pdf })
+        });
+        this.map.addControl(new PrintControl());
+
 
         // Set up the base maps
         this.baseLayer = L.tileLayer(settings.baseLayer);


### PR DESCRIPTION
Adds a simple control to produce a PDF of the currently focused map region using Datamade's Lascaux. 

![screen shot 2015-04-24 at 12 00 26 pm](https://cloud.githubusercontent.com/assets/86435/7322985/8e312602-ea79-11e4-91b3-cdd45ca78db1.png)
