### PR TITLE
Show a parcel's entries in reverse chronological order

### DIFF
--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -259,7 +259,8 @@ define(function (require) {
       // map, and so the object in question hasn't been highlighted on the map.
       var rc = new Responses.Collection([], {
         surveyId: this.survey.get('id'),
-        objectId: objectId
+        objectId: objectId,
+        sort: 'desc'
       });
 
       var surveyOptions = this.survey.get('surveyOptions') || {};

--- a/src/js/views/responses/responses.js
+++ b/src/js/views/responses/responses.js
@@ -195,7 +195,8 @@ define(function(require, exports, module) {
       // map, and so the object in question hasn't been highlighted on the map.
       var rc = new Responses.Collection([], {
         surveyId: this.survey.get('id'),
-        objectId: objectId
+        objectId: objectId,
+        sort: 'desc'
       });
 
       var surveyOptions = this.survey.get('surveyOptions') || {};
@@ -489,7 +490,8 @@ define(function(require, exports, module) {
 
       var rc = new Responses.Collection([], {
         surveyId: this.survey.get('id'),
-        objectId: event.data.object_id
+        objectId: event.data.object_id,
+        sort: 'desc'
       });
 
       var surveyOptions = this.survey.get('surveyOptions') || {};


### PR DESCRIPTION
Specify sort order for entries in the object details view.
Maintain specified sort order in a Response collection