### PR TITLE
Don't let users submit questions or answers that are blank

### DIFF
--- a/src/css/sass/components/editor.scss
+++ b/src/css/sass/components/editor.scss
@@ -77,6 +77,10 @@
     position: relative;
   }
 
+  input.blank {
+    border-color: $red;
+  }
+
   .question .question,
   .answers {
     border-left: $editor-border solid #fff;
@@ -101,11 +105,11 @@
       padding-left: 45px;
     }
   }
-  
+
   .add-question-container {
     padding-bottom: 8px;
   }
-  
+
 
   .question-tools-container,
   .show-add-sub-question,

--- a/src/js/templates/surveys/form-editor.html
+++ b/src/js/templates/surveys/form-editor.html
@@ -6,6 +6,7 @@
 
       <!-- <button class="mini flex done">Close editor</button> -->
       <div class="saved">Form saved</div>
+      <div class="formSaveError error">Error saving the form</div>
 
       <div id="editor" class="editor"></div>
 

--- a/src/js/views/builder.js
+++ b/src/js/views/builder.js
@@ -77,9 +77,32 @@ define(function (require) {
       this.renderForm();
     },
 
+    formIsValid: function() {
+      // Find questions without answers
+      var emptyQuestions = this.formQuestions.find('input:text[value=""]');
+      if (emptyQuestions.length === 0) {
+        return true;
+      }
+
+      emptyQuestions.addClass('blank');
+      emptyQuestions.keyup(function(event) {
+        $(event.target).removeClass('blank');
+      });
+      return false;
+    },
+
     save: function(event) {
       event.preventDefault();
       console.log('Saving form');
+      $('.formSaveError').html('').hide();
+
+      var valid = this.formIsValid();
+      if (!valid) {
+        $('.formSaveError').html('Please ensure all questions and answers have text.');
+        $('.formSaveError').fadeIn();
+        return;
+      }
+
       util.track('survey.form.save');
 
       api.createForm(this.forms.getMostRecentForm().toJSON(), function(){
@@ -254,6 +277,7 @@ define(function (require) {
 
         var newQuestion = this.makeBlankQuestion();
         newQuestion.type = 'file';
+
         delete newQuestion.answers;
         parent.splice(questionIndex + 1, 0, newQuestion);
 


### PR DESCRIPTION
Instead, give a warning and highlight the offending fields. Fixes #359.