### PR TITLE
Use PUT instead of PATCH to edit response answers.

### DIFF
--- a/src/css/sass/components/surveys.scss
+++ b/src/css/sass/components/surveys.scss
@@ -145,6 +145,10 @@
     margin-bottom: 1em;
   }
 
+  .editanswers {
+    display: none;
+  }
+
   .response {
     padding: 10px 0;
     border-top: 4px solid $thinpink;
@@ -164,10 +168,7 @@
       }
     }
 
-
-
     .response-tools {
-
       /* Potential toolbar styling
       background: $thinpink;
       margin-left: -20px;
@@ -206,10 +207,6 @@
 
     button.action-save-edit,
     button.action-cancel-edit {
-      display: none;
-    }
-
-    .edit {
       display: none;
     }
 

--- a/src/js/templates/responses/item.html
+++ b/src/js/templates/responses/item.html
@@ -63,26 +63,51 @@
             </span>
           <% } %>
         <% } %>
-
-        <% if (field.type === 'text') { %>
-          <textarea class="edit" data-question="<%- field.questionSlug %>"><%- field.answer %></textarea>
-        <% } else { %>
-          <select class="edit" data-question="<%- field.questionSlug %>">
-            <% if (field.answerOptions) { %>
-              <% _.forEach(field.answerOptions, function (option) { %>
-                <option
-                  value="<%- option.slug %>"
-                  <% if (field.answerSlug === option.slug) { %> selected="selected" <% } %>>
-                  <%- option.text %>
-                </option>
-              <% }); %>
-            <% } %>
-          </select>
-        <% } %>
-
       </div>
     <% }) %>
   <% } %>
+</div>
+
+<div class="editanswers">
+  <% _.forEach(fields, function (field) { %>
+    <div class="answer">
+      <span class="key">
+        <%- field.question %>
+      </span>
+      <% if (field.type === 'text') { %>
+        <span class="value">
+          <%= autolinker.link(_.escape(field.answer)) %>
+        </span>
+      <% } else { %>
+        <span class="value">
+          <%- field.answer %>
+        </span>
+      <% } %>
+
+      <% if (field.type === 'text') { %>
+        <textarea class="edit" data-question="<%- field.questionSlug %>"><%- field.answer %></textarea>
+      <% } else { %>
+        <select class="edit" data-question="<%- field.questionSlug %>">
+          <option
+            value="no response"
+            <% if (field.answerSlug === undefined) { %> selected="selected" <% } %>>
+            No response
+          </option>
+
+          <% if (field.answerOptions) { %>
+            <% _.forEach(field.answerOptions, function (option) { %>
+              <option
+                value="<%- option.slug %>"
+                <% if (field.answerSlug === option.slug) { %> selected="selected" <% } %>>
+                <%- option.text %>
+              </option>
+            <% }); %>
+          <% } %>
+        </select>
+      <% } %>
+
+    </div>
+  <% }) %>
 </div>
 
 <% if (surveyOptions.loggedIn) { %>


### PR DESCRIPTION
A couple changes in the way editing responses works: 
- The edit view shows all possible questions (ignoring skip logic), giving survey managers more control. A future version could better visually distinguish question hierarchy. 
- We use PUT instead of PATCH to support removing answers