### PR TITLE
Lots to Love styling

### DIFF
--- a/src/js/templates/projects/surveys/explore-sparse-styles.mss
+++ b/src/js/templates/projects/surveys/explore-sparse-styles.mss
@@ -28,7 +28,10 @@ background-color: rgba(0,0,0,0);
     line-opacity: 1;
   }
   [GEOMETRY = Polygon],[GEOMETRY = MultiPolygon] {
-    [zoom >= 14] {
+    line-color: <%= color %>;
+    line-width:4;
+    line-opacity:1;
+    [zoom >= 15] {
       line-color: <%= color %>;
       line-width:0.5;
       line-opacity:0.5;
@@ -74,7 +77,10 @@ background-color: rgba(0,0,0,0);
     line-opacity: 1;
   }
   [GEOMETRY = Polygon],[GEOMETRY = MultiPolygon] {
-    [zoom >= 14] {
+    line-color: <%= pair.color %>;
+    line-width:4;
+    line-opacity:1;
+    [zoom >= 15] {
       line-color: <%= pair.color %>;
       line-width:0.5;
       line-opacity:0.5;

--- a/src/js/views/projects/project-utils.js
+++ b/src/js/views/projects/project-utils.js
@@ -6,6 +6,7 @@ define(function(require, exports, module) {
 
   var _ = require('lib/lodash');
   var exploreStylesTemplate = require('text!templates/projects/surveys/explore-styles.mss');
+  var exploreSparseStylesTemplate = require('text!templates/projects/surveys/explore-sparse-styles.mss');
   var simpleStylesTemplate = require('text!templates/projects/surveys/simple-styles.mss');
   var complexStylesTemplate = require('text!templates/projects/surveys/explore-complex-styles.mss');
   var keyValueStylesTemplate = require('text!templates/projects/surveys/key-value-styles.mss');
@@ -16,6 +17,12 @@ define(function(require, exports, module) {
       return template(_.defaults(options, { pointSize: 18 }));
     };
   }(_.template(exploreStylesTemplate)));
+
+  var exploreSparseStyles = (function (template) {
+    return function (options) {
+      return template(_.defaults(options, { pointSize: 18 }));
+    };
+  }(_.template(exploreSparseStylesTemplate)));
 
   var simpleStyles = (function (template) {
     return function (options) {
@@ -47,6 +54,11 @@ define(function(require, exports, module) {
     // values: ['Yes', 'No'],
     // valueNames: ['Unsafe', 'No significant issue'],
     // colors: ['#d73027', '#1a9850']
+    var styles = exploreStyles;
+    if (options.sparse) {
+      styles = exploreSparseStyles;
+    }
+
     var data = {
       name: options.name,
       question: options.question,
@@ -54,7 +66,7 @@ define(function(require, exports, module) {
       layer: {
         query: options.query,
         select: { 'entries.responses': 1 },
-        styles: exploreStyles({
+        styles: styles({
           showNoResponse: !!options.showNoResponse,
           pairs: _.map(options.values, function (val, i) {
             var ret = {
@@ -291,6 +303,7 @@ define(function(require, exports, module) {
 
   return {
     exploreStyles: exploreStyles,
+    exploreSparseStyles: exploreSparseStyles,
     simpleStyles: simpleStyles,
     checkboxStyles: checkboxStyles,
     makeBasicExploration: makeBasicExploration,

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -47,6 +47,7 @@ define(function(require, exports, module) {
         styles: util.simpleStyles({color: '#cddc29'}),
         exploration: [
           util.makeBasicExploration({
+            sparse: true,
             name: 'Project Status',
             question: 'What-stage-of-project-are-you-registering',
             values: [
@@ -62,6 +63,7 @@ define(function(require, exports, module) {
             colors: ['#F0532D', '#00C1f3', '#12B259']
           }),
           util.makeBasicExploration({
+            sparse: true,
             name: 'Project Type',
             question: 'Project-Type',
             values: [

--- a/src/js/views/projects/projects.js
+++ b/src/js/views/projects/projects.js
@@ -102,11 +102,11 @@ define(function(require, exports, module) {
           type: 'feature-tiles',
           layerName: 'Vacant Properties',
           attribution: 'Pennsylvania Spatial Data Access',
-          state: 'active',
+          state: 'inactive',
           color: '#505050',
           zIndex: 25,
           handleClick: true,
-          staticLegend: '<div><i class="fa fa-square" style="color:#12b259"></i> Side Yards</div> <div><i class="fa fa-square" style="color:#101010"></i> Publicly owned</div> <div><i class="fa fa-square" style="color:#777777"></i> Privately owned</div>',
+          staticLegend: '<div><i class="fa fa-square" style="color:#005e20;opacity:0.6;"></i> Side Yards</div> <div><i class="fa fa-square" style="color:#101010;opacity:0.6;"></i> Publicly owned</div> <div><i class="fa fa-square" style="color:#777777;opacity:0.6;"></i> Privately owned</div>',
           fieldNames: {
             mapblolot: 'Parcel ID',
             mundesc: 'Municipality',
@@ -117,7 +117,7 @@ define(function(require, exports, module) {
           layer: {
             query: { source: 'allegheny-assessed-parcels' },
             select: { },
-            styles: '[GEOMETRY = Polygon], [GEOMETRY = MultiPolygon] {\n ["info.fairmarket" <= 0]{ polygon-fill: #777; polygon-opacity: 0.6;\n}\n ["info.fairmarket" <= 0]{\n ["info.publicowne" = "C"], ["info.publicowne" = "E"], ["info.publicowne" = "H"], ["info.publicowne" = "R"], ["info.publicowne" = "S"], ["info.publicowne" = "U"], ["info.publicowne" = "A"], ["info.publicowne" = "M"] {\n polygon-fill: #101010; polygon-opacity: 0.6;\n}\n}\n ["info.fairmarket" <= 0]["info.sidelot" >= 1],["info.sidelot" >= 1]{ polygon-fill: #12B259; polygon-opacity: 0.6; } polygon-opacity: 0;\n [zoom >= 15] {\n line-color: #FFF; line-width: 0.5; line-opacity: 0.7; }\n line-width: 0; line-opacity: 0; line-color: #FFF;\n }',
+            styles: '[GEOMETRY = Polygon], [GEOMETRY = MultiPolygon] {\n ["info.fairmarket" <= 0]{ polygon-fill: #777; polygon-opacity: 0.6;\n}\n ["info.fairmarket" <= 0]{\n ["info.publicowne" = "C"], ["info.publicowne" = "E"], ["info.publicowne" = "H"], ["info.publicowne" = "R"], ["info.publicowne" = "S"], ["info.publicowne" = "U"], ["info.publicowne" = "A"], ["info.publicowne" = "M"] {\n polygon-fill: #101010; polygon-opacity: 0.6;\n}\n}\n ["info.fairmarket" <= 0]["info.sidelot" >= 1],["info.sidelot" >= 1]{ polygon-fill: #005e20; polygon-opacity: 0.6; } polygon-opacity: 0;\n [zoom >= 15] {\n line-color: #FFF; line-width: 0.5; line-opacity: 0.7; }\n line-width: 0; line-opacity: 0; line-color: #FFF;\n }',
           },
           layerId: 'allegheny-assessed-parcels'
         },


### PR DESCRIPTION
Improve balance of points against other features when zoomed out (helps Lots to Love and Walkscope).

Add a style template for projects with sparse polygon data mixed with points, emphasizing polygon outlines at low zooms to improve balance.

Update Lots to Love styling based on feedback from users via GTECH.