### PR TITLE
Avoid using JSONP for grids when the browser will support CORS requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ staging
 .sass-cache/
 .sass-cache/*
 .DS_Store
+.eslintrc

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -117,5 +117,7 @@ function(L) {
     'fillColor': '#fcd96c'
   };
 
+  settings.cors = ('withCredentials' in new XMLHttpRequest());
+
   return settings;
 });

--- a/src/js/views/map.js
+++ b/src/js/views/map.js
@@ -128,7 +128,8 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
       var gridConfig = util.templatizeURLs(tilejson.grids);
       this.gridLayer = new L.UtfGrid(gridConfig.template, {
         resolution: 4,
-        subdomains: gridConfig.subs
+        subdomains: gridConfig.subs,
+        useJsonP: !settings.cors
       });
 
       // Make sure the grid layer is on top.
@@ -315,11 +316,15 @@ function($, _, Backbone, L, moment, settings, util, api, template) {
       }
       url = url + '/tile.json';
 
+      // If we have CORS support, indicate to the tileserver that we don't want
+      // a jsonp callback template in the grid URLs.
+      var data = _.defaults({ jsonp: !settings.cors }, this.mapOptions);
+
       // Get TileJSON
       $.ajax({
         url: url,
         dataType: 'json',
-        data: this.mapOptions,
+        data: data,
         cache: false
       }).done(this.addTileLayer)
       .fail(function(jqXHR, textStatus, errorThrown) {

--- a/src/js/views/maps/feature-tiles-layer.js
+++ b/src/js/views/maps/feature-tiles-layer.js
@@ -11,6 +11,7 @@ define(function (require, exports, module) {
   var Promise = require('lib/bluebird');
 
   var api = require('api');
+  var settings = require('settings');
   var util = require('util');
 
   // We reuse the cartodb layer templates
@@ -43,9 +44,14 @@ define(function (require, exports, module) {
 
       var self = this;
 
+      var url = '/tiles/features/tile.json';
+      if (settings.cors) {
+        url += '?jsonp=false';
+      }
+
       // Now we need to start loading the tiles
       Promise.resolve($.ajax({
-        url: '/tiles/features/tile.json',
+        url: url,
         type: 'POST',
         contentType: 'application/json',
         data: JSON.stringify(this.layerOptions.layer)
@@ -75,7 +81,8 @@ define(function (require, exports, module) {
         var gridConfig = util.templatizeURLs(data.grids);
         this.gridLayer = new L.UtfGrid(gridConfig.template, {
           resolution: 4,
-          subdomains: gridConfig.subs
+          subdomains: gridConfig.subs,
+          useJsonP: !settings.cors
         });
 
         if (this.state === 'active') {

--- a/src/js/views/projects/datalayers/survey.js
+++ b/src/js/views/projects/datalayers/survey.js
@@ -165,11 +165,14 @@ define(function (require) {
         data = _.find(filterDefs, { name: filter.answer }).layer;
       }
 
+      var url = '/tiles/surveys/' + this.surveyId + '/tile.json';
+      if (settings.cors) {
+        url += '?jsonp=false';
+      }
+
       // Get TileJSON
-      // TODO: Switch this to a POST once we support proxying the post to the
-      // tile server through the API.
       $.ajax({
-        url: '/tiles/surveys/' + this.surveyId + '/tile.json',
+        url: url,
         type: 'POST',
         dataType: 'json',
         cache: false,
@@ -203,7 +206,8 @@ define(function (require) {
         this.mapView.removeTileLayer(this.gridLayer);
       }
       this.gridLayer = new L.UtfGrid(tilejson.grids[0], {
-        resolution: 4
+        resolution: 4,
+        useJsonP: !settings.cors
       });
       this.gridLayer.on('click', this.handleClick);
 


### PR DESCRIPTION
This should help a little with grid caching, since the grid response content will be the same regardless of load order/etc. With JSONP, the callback names can change, leading to cache misses.

This change depends on https://github.com/LocalData/localdata-tiles/pull/158