### PR TITLE
Add clarity to multiple choice questions

### DIFF
--- a/src/js/models/forms.js
+++ b/src/js/models/forms.js
@@ -117,7 +117,8 @@ function($, _, Backbone, settings) {
               type: 'checkbox',
               slug: item.name,
               id: id,
-              text: item.text
+              text: item.text,
+              parentName: old.text
             });
             subs.push({
               questions: item.questions,

--- a/src/js/templates/responses/item.html
+++ b/src/js/templates/responses/item.html
@@ -51,6 +51,9 @@
       <div class="answer">
         <% if (field.answer !== undefined) { %>
           <span class="key">
+            <% if (field.parentName !== undefined) { %>
+              <%- field.parentName %><br>
+            <% } %>
             <%- field.question %>
           </span>
           <% if (field.type === 'text') { %>

--- a/src/js/views/responses/item.js
+++ b/src/js/views/responses/item.js
@@ -124,7 +124,8 @@ define(function (require) {
             type: question.type,
             answer: value,
             answerSlug: valueSlug,
-            answerOptions: answers
+            answerOptions: answers,
+            parentName: question.parentName
           });
 
           processed[question.slug] = true;


### PR DESCRIPTION
Show the "parent question" of each multiple choice question. 

Eg if the question is "Siding type" and the answers are:
* Brick
* Vinyl 
* None

The result will display in the detail view as 
```
Siding type
Brick
yes
```

Not the cleanest (ideally we could just say "siding type: brick") but this keeps the detail view consistent with the deep dive and exports. 